### PR TITLE
feat(privacy): Granular Post Privacy Controls (#7)

### DIFF
--- a/frontend/src/components/CircleManager.js
+++ b/frontend/src/components/CircleManager.js
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+
+function CircleManager({ circles, friends, onCreateCircle, onDeleteCircle, onAddMember, onRemoveMember }) {
+  const [circleName, setCircleName] = useState('');
+  const [circleColor, setCircleColor] = useState('#3B82F6');
+
+  const handleCreate = (event) => {
+    event.preventDefault();
+    const name = circleName.trim();
+    if (!name) return;
+    onCreateCircle({ name, color: circleColor });
+    setCircleName('');
+  };
+
+  return (
+    <div className="bg-white rounded-xl shadow p-6 border border-gray-100 space-y-4">
+      <h3 className="text-lg font-semibold text-gray-900">Circle Manager</h3>
+
+      <form onSubmit={handleCreate} className="grid grid-cols-1 md:grid-cols-3 gap-2">
+        <input
+          value={circleName}
+          onChange={(event) => setCircleName(event.target.value)}
+          className="border rounded p-2"
+          placeholder="Circle name"
+          maxLength={50}
+        />
+        <input
+          type="color"
+          value={circleColor}
+          onChange={(event) => setCircleColor(event.target.value)}
+          className="border rounded p-1 h-10"
+        />
+        <button type="submit" className="bg-blue-600 text-white rounded px-4 py-2 hover:bg-blue-700">
+          Create Circle
+        </button>
+      </form>
+
+      <div className="space-y-3">
+        {circles.map((circle) => (
+          <div key={circle.name} className="border rounded p-3">
+            <div className="flex justify-between items-center mb-2">
+              <div className="flex items-center gap-2">
+                <span className="w-3 h-3 rounded-full" style={{ backgroundColor: circle.color || '#3B82F6' }} />
+                <span className="font-medium text-gray-900">{circle.name}</span>
+                <span className="text-sm text-gray-500">({circle.memberCount || 0})</span>
+              </div>
+              <button
+                type="button"
+                onClick={() => onDeleteCircle(circle.name)}
+                className="text-sm text-red-600 hover:text-red-700"
+              >
+                Delete
+              </button>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+              {friends.map((friend) => {
+                const isMember = (circle.members || []).some((member) => String(member._id) === String(friend._id));
+                return (
+                  <label key={`${circle.name}-${friend._id}`} className="flex items-center justify-between text-sm border rounded px-2 py-1">
+                    <span>{friend.realName || friend.username}</span>
+                    <input
+                      type="checkbox"
+                      checked={isMember}
+                      onChange={() => {
+                        if (isMember) {
+                          onRemoveMember(circle.name, friend._id);
+                        } else {
+                          onAddMember(circle.name, friend._id);
+                        }
+                      }}
+                    />
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+        {circles.length === 0 && <p className="text-sm text-gray-500">No circles yet.</p>}
+      </div>
+    </div>
+  );
+}
+
+export default CircleManager;

--- a/frontend/src/components/PrivacySelector.js
+++ b/frontend/src/components/PrivacySelector.js
@@ -1,0 +1,118 @@
+import React from 'react';
+
+const VISIBILITY_OPTIONS = [
+  { value: 'public', label: 'Public' },
+  { value: 'friends', label: 'Friends' },
+  { value: 'circles', label: 'Specific Circles' },
+  { value: 'specific_users', label: 'Specific Users' },
+  { value: 'private', label: 'Private' }
+];
+
+function PrivacySelector({
+  form,
+  circles,
+  friends,
+  onChange,
+  onToggleCircle,
+  onToggleVisibleUser,
+  onToggleExcludeUser
+}) {
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Visibility</label>
+        <select
+          value={form.visibility}
+          onChange={(event) => onChange('visibility', event.target.value)}
+          className="w-full border rounded p-2"
+        >
+          {VISIBILITY_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>{option.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {form.visibility === 'circles' && (
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Circles</label>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+            {circles.map((circle) => (
+              <label key={circle.name} className="flex items-center gap-2 text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  checked={form.visibleToCircles.includes(circle.name)}
+                  onChange={() => onToggleCircle(circle.name)}
+                />
+                <span>{circle.name} ({circle.memberCount || 0})</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {form.visibility === 'specific_users' && (
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Specific Users</label>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2 max-h-40 overflow-auto border rounded p-2">
+            {friends.map((friend) => (
+              <label key={friend._id} className="flex items-center gap-2 text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  checked={form.visibleToUsers.includes(friend._id)}
+                  onChange={() => onToggleVisibleUser(friend._id)}
+                />
+                <span>{friend.realName || friend.username}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Exclude Users</label>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-2 max-h-40 overflow-auto border rounded p-2">
+          {friends.map((friend) => (
+            <label key={`exclude-${friend._id}`} className="flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={form.excludeUsers.includes(friend._id)}
+                onChange={() => onToggleExcludeUser(friend._id)}
+              />
+              <span>{friend.realName || friend.username}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Location Radius (miles)</label>
+          <input
+            type="number"
+            min="1"
+            max="1000"
+            value={form.locationRadius}
+            onChange={(event) => onChange('locationRadius', event.target.value)}
+            className="w-full border rounded p-2"
+            placeholder="Optional"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Expires In</label>
+          <select
+            value={form.expirationPreset}
+            onChange={(event) => onChange('expirationPreset', event.target.value)}
+            className="w-full border rounded p-2"
+          >
+            <option value="none">No Expiration</option>
+            <option value="24h">24 Hours</option>
+            <option value="7d">7 Days</option>
+            <option value="30d">30 Days</option>
+          </select>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default PrivacySelector;

--- a/frontend/src/pages/Social.js
+++ b/frontend/src/pages/Social.js
@@ -1,12 +1,21 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { authAPI, feedAPI, galleryAPI } from '../utils/api';
+import { authAPI, circlesAPI, feedAPI, friendsAPI, galleryAPI } from '../utils/api';
+import PrivacySelector from '../components/PrivacySelector';
+import CircleManager from '../components/CircleManager';
 
-const VISIBILITY_OPTIONS = ['public', 'friends', 'private'];
 const MEDIA_URL_MAX_ITEMS = 8;
 const MEDIA_URL_MAX_LENGTH = 2048;
 const GALLERY_MAX_ITEMS = 24;
 const GALLERY_MAX_IMAGE_SIZE_BYTES = 3 * 1024 * 1024;
+
+const PRIVACY_BADGE_LABELS = {
+  public: 'Public',
+  friends: 'Friends',
+  circles: 'Circles',
+  specific_users: 'Specific Users',
+  private: 'Private'
+};
 
 const isRenderableMediaUrl = (value) => {
   if (typeof value !== 'string') return false;
@@ -144,7 +153,14 @@ const Social = () => {
     mediaUrlInput: '',
     mediaUrls: [],
     visibility: 'public',
+    visibleToCircles: [],
+    visibleToUsers: [],
+    excludeUsers: [],
+    locationRadius: '',
+    expirationPreset: 'none',
   });
+  const [circles, setCircles] = useState([]);
+  const [friends, setFriends] = useState([]);
   const [commentInputs, setCommentInputs] = useState({});
   const [actionLoadingByPost, setActionLoadingByPost] = useState({});
   const [galleryItems, setGalleryItems] = useState([]);
@@ -234,6 +250,13 @@ const Social = () => {
     const profileResponse = await authAPI.getProfile();
     const user = profileResponse.data?.user;
     setCurrentUser(user || null);
+
+    const [circlesResponse, friendsResponse] = await Promise.all([
+      circlesAPI.getCircles().catch(() => ({ data: { circles: [] } })),
+      friendsAPI.getFriends().catch(() => ({ data: { friends: [] } }))
+    ]);
+    setCircles(Array.isArray(circlesResponse.data?.circles) ? circlesResponse.data.circles : []);
+    setFriends(Array.isArray(friendsResponse.data?.friends) ? friendsResponse.data.friends : []);
 
     const timelineResponse = await feedAPI.getTimeline();
     const timelinePosts = Array.isArray(timelineResponse.data?.posts)
@@ -329,6 +352,87 @@ const Social = () => {
     }));
   };
 
+  const handlePostFormField = (field, value) => {
+    setPostForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const toggleStringInArray = (list, value) => {
+    if (list.includes(value)) {
+      return list.filter((entry) => entry !== value);
+    }
+    return [...list, value];
+  };
+
+  const handleToggleCircle = (circleName) => {
+    setPostForm((prev) => ({
+      ...prev,
+      visibleToCircles: toggleStringInArray(prev.visibleToCircles, circleName)
+    }));
+  };
+
+  const handleToggleVisibleUser = (userId) => {
+    setPostForm((prev) => ({
+      ...prev,
+      visibleToUsers: toggleStringInArray(prev.visibleToUsers, userId)
+    }));
+  };
+
+  const handleToggleExcludeUser = (userId) => {
+    setPostForm((prev) => ({
+      ...prev,
+      excludeUsers: toggleStringInArray(prev.excludeUsers, userId)
+    }));
+  };
+
+  const refreshCircles = async () => {
+    try {
+      const response = await circlesAPI.getCircles();
+      setCircles(Array.isArray(response.data?.circles) ? response.data.circles : []);
+    } catch {
+      setCircles([]);
+    }
+  };
+
+  const handleCreateCircle = async (payload) => {
+    try {
+      await circlesAPI.createCircle(payload);
+      await refreshCircles();
+    } catch (error) {
+      setFeedError(error.response?.data?.error || 'Failed to create circle.');
+    }
+  };
+
+  const handleDeleteCircle = async (circleName) => {
+    try {
+      await circlesAPI.deleteCircle(circleName);
+      await refreshCircles();
+      setPostForm((prev) => ({
+        ...prev,
+        visibleToCircles: prev.visibleToCircles.filter((entry) => entry !== circleName)
+      }));
+    } catch (error) {
+      setFeedError(error.response?.data?.error || 'Failed to delete circle.');
+    }
+  };
+
+  const handleAddCircleMember = async (circleName, userId) => {
+    try {
+      await circlesAPI.addMember(circleName, userId);
+      await refreshCircles();
+    } catch (error) {
+      setFeedError(error.response?.data?.error || 'Failed to add circle member.');
+    }
+  };
+
+  const handleRemoveCircleMember = async (circleName, userId) => {
+    try {
+      await circlesAPI.removeMember(circleName, userId);
+      await refreshCircles();
+    } catch (error) {
+      setFeedError(error.response?.data?.error || 'Failed to remove circle member.');
+    }
+  };
+
   const handleSubmitPost = async (event) => {
     event.preventDefault();
     if (!currentUser?._id) return;
@@ -342,10 +446,24 @@ const Social = () => {
     setSubmittingPost(true);
     setFeedError('');
     try {
+      let expiresAt = null;
+      if (postForm.expirationPreset === '24h') {
+        expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+      } else if (postForm.expirationPreset === '7d') {
+        expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+      } else if (postForm.expirationPreset === '30d') {
+        expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+      }
+
       const response = await feedAPI.createPost({
         content,
         mediaUrls: postForm.mediaUrls,
         visibility: postForm.visibility,
+        visibleToCircles: postForm.visibleToCircles,
+        visibleToUsers: postForm.visibleToUsers,
+        excludeUsers: postForm.excludeUsers,
+        locationRadius: postForm.locationRadius ? Number(postForm.locationRadius) : null,
+        expiresAt,
         targetFeedId: currentUser._id,
       });
 
@@ -361,6 +479,11 @@ const Social = () => {
         mediaUrlInput: '',
         mediaUrls: [],
         visibility: 'public',
+        visibleToCircles: [],
+        visibleToUsers: [],
+        excludeUsers: [],
+        locationRadius: '',
+        expirationPreset: 'none',
       });
     } catch (error) {
       setFeedError(error.response?.data?.error || 'Failed to publish post.');
@@ -790,20 +913,15 @@ const Social = () => {
                 )}
               </div>
 
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Visibility</label>
-                <select
-                  value={postForm.visibility}
-                  onChange={(event) => setPostForm((prev) => ({ ...prev, visibility: event.target.value }))}
-                  className="border rounded px-3 py-2"
-                >
-                  {VISIBILITY_OPTIONS.map((option) => (
-                    <option key={option} value={option}>
-                      {option}
-                    </option>
-                  ))}
-                </select>
-              </div>
+              <PrivacySelector
+                form={postForm}
+                circles={circles}
+                friends={friends}
+                onChange={handlePostFormField}
+                onToggleCircle={handleToggleCircle}
+                onToggleVisibleUser={handleToggleVisibleUser}
+                onToggleExcludeUser={handleToggleExcludeUser}
+              />
 
               <button
                 type="submit"
@@ -813,6 +931,17 @@ const Social = () => {
                 {submittingPost ? 'Publishing...' : 'Publish Post'}
               </button>
             </form>
+          )}
+
+          {isAuthenticated && (
+            <CircleManager
+              circles={circles}
+              friends={friends}
+              onCreateCircle={handleCreateCircle}
+              onDeleteCircle={handleDeleteCircle}
+              onAddMember={handleAddCircleMember}
+              onRemoveMember={handleRemoveCircleMember}
+            />
           )}
 
           <section className="space-y-4">
@@ -853,9 +982,23 @@ const Social = () => {
                         <p className="text-xs text-gray-500">{formatDate(post.createdAt)}</p>
                       </div>
                       <span className="text-xs uppercase tracking-wide bg-gray-100 px-2 py-1 rounded">
-                        {post.visibility}
+                        {PRIVACY_BADGE_LABELS[post.visibility] || post.visibility}
                       </span>
                     </header>
+
+                    <div className="flex flex-wrap gap-2 text-xs text-gray-600">
+                      {Array.isArray(post.visibleToCircles) && post.visibleToCircles.length > 0 && (
+                        <span className="bg-gray-100 px-2 py-1 rounded">
+                          Circles: {post.visibleToCircles.join(', ')}
+                        </span>
+                      )}
+                      {post.locationRadius ? (
+                        <span className="bg-gray-100 px-2 py-1 rounded">Radius: {post.locationRadius} mi</span>
+                      ) : null}
+                      {post.expiresAt ? (
+                        <span className="bg-gray-100 px-2 py-1 rounded">Expires: {formatDate(post.expiresAt)}</span>
+                      ) : null}
+                    </div>
 
                     {post.content && <p className="text-gray-800 whitespace-pre-wrap">{post.content}</p>}
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -68,7 +68,7 @@ export const userAPI = {
 // Feed API
 export const feedAPI = {
   getUserFeed: (userId, page = 1, limit = 20) => 
-    api.get(`/feed/${userId}?page=${page}&limit=${limit}`),
+    api.get(`/feed/user/${userId}?page=${page}&limit=${limit}`),
   getPublicUserFeed: (userIdOrUsername, page = 1, limit = 20) =>
     api.get(`/public/users/${encodeURIComponent(userIdOrUsername)}/feed?page=${page}&limit=${limit}`),
   createPost: (data) => api.post('/feed/post', data),
@@ -244,6 +244,15 @@ export const friendsAPI = {
   updatePrivacySettings: (data) => api.put('/friends/privacy', data),
   // Get relationship status
   getRelationship: (userId) => api.get(`/friends/relationship/${userId}`),
+};
+
+export const circlesAPI = {
+  getCircles: () => api.get('/circles'),
+  createCircle: (data) => api.post('/circles', data),
+  updateCircle: (circleName, data) => api.put(`/circles/${encodeURIComponent(circleName)}`, data),
+  deleteCircle: (circleName) => api.delete(`/circles/${encodeURIComponent(circleName)}`),
+  addMember: (circleName, userId) => api.post(`/circles/${encodeURIComponent(circleName)}/members`, { userId }),
+  removeMember: (circleName, userId) => api.delete(`/circles/${encodeURIComponent(circleName)}/members/${encodeURIComponent(userId)}`),
 };
 
 // News API

--- a/models/Post.js
+++ b/models/Post.js
@@ -1,5 +1,26 @@
 const mongoose = require('mongoose');
 
+const EARTH_RADIUS_MILES = 3958.8;
+
+const toRadians = (degrees) => (Number(degrees) * Math.PI) / 180;
+
+const calculateMiles = (origin, destination) => {
+  if (!origin || !destination) return null;
+  const [lon1, lat1] = origin;
+  const [lon2, lat2] = destination;
+  if (![lon1, lat1, lon2, lat2].every((value) => Number.isFinite(Number(value)))) {
+    return null;
+  }
+
+  const dLat = toRadians(lat2 - lat1);
+  const dLon = toRadians(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2)
+    + Math.cos(toRadians(lat1)) * Math.cos(toRadians(lat2)) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_MILES * c;
+};
+
 const postSchema = new mongoose.Schema({
   authorId: {
     type: mongoose.Schema.Types.ObjectId,
@@ -28,8 +49,32 @@ const postSchema = new mongoose.Schema({
   },
   visibility: {
     type: String,
-    enum: ['public', 'friends', 'private'],
+    enum: ['public', 'friends', 'circles', 'specific_users', 'private'],
     default: 'public'
+  },
+  visibleToCircles: [{
+    type: String,
+    trim: true,
+    maxlength: 50
+  }],
+  visibleToUsers: [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  }],
+  excludeUsers: [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  }],
+  locationRadius: {
+    type: Number,
+    default: null,
+    min: 1,
+    max: 1000
+  },
+  expiresAt: {
+    type: Date,
+    default: null,
+    index: true
   },
   location: {
     type: {
@@ -92,12 +137,62 @@ postSchema.index({ location: '2dsphere' });
 postSchema.index({ targetFeedId: 1, createdAt: -1 });
 postSchema.index({ authorId: 1, createdAt: -1 });
 postSchema.index({ visibility: 1, createdAt: -1 });
+postSchema.index({ authorId: 1, visibility: 1, createdAt: -1 });
+postSchema.index({ expiresAt: 1 });
 
 // Method to check if user can view post
-postSchema.methods.canView = function(userId, isFriend = false) {
-  if (this.visibility === 'public') return true;
-  if (this.visibility === 'friends' && isFriend) return true;
-  if (this.visibility === 'private' && this.targetFeedId.toString() === userId.toString()) return true;
+postSchema.methods.canView = function(viewerId, context = {}) {
+  if (!viewerId) return this.visibility === 'public';
+
+  const viewer = String(viewerId);
+  const author = String(this.authorId);
+  const target = String(this.targetFeedId);
+
+  if (this.expiresAt && this.expiresAt.getTime() < Date.now()) {
+    return false;
+  }
+
+  if (author === viewer || target === viewer) {
+    return true;
+  }
+
+  const excludedIds = Array.isArray(this.excludeUsers)
+    ? this.excludeUsers.map((entry) => String(entry))
+    : [];
+  if (excludedIds.includes(viewer)) {
+    return false;
+  }
+
+  const enforceLocationRadius = () => {
+    if (!this.locationRadius || !Array.isArray(this.location?.coordinates)) {
+      return true;
+    }
+    if (!Array.isArray(context.viewerCoordinates)) {
+      return false;
+    }
+    const miles = calculateMiles(this.location.coordinates, context.viewerCoordinates);
+    return Number.isFinite(miles) ? miles <= this.locationRadius : false;
+  };
+
+  if (this.visibility === 'public') {
+    return enforceLocationRadius();
+  }
+
+  if (this.visibility === 'friends') {
+    return !!context.isFriend;
+  }
+
+  if (this.visibility === 'circles' || this.visibility === 'specific_users') {
+    const allowedUsers = Array.isArray(this.visibleToUsers)
+      ? this.visibleToUsers.map((entry) => String(entry))
+      : [];
+    return allowedUsers.includes(viewer);
+  }
+
+  if (this.visibility === 'private') {
+    return author === viewer || target === viewer;
+  }
+
   return false;
 };
 

--- a/models/User.js
+++ b/models/User.js
@@ -127,6 +127,28 @@ const userSchema = new mongoose.Schema({
     enum: ['public', 'friends', 'private'],
     default: 'public'
   },
+  circles: [{
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: 50
+    },
+    members: [{
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User'
+    }],
+    color: {
+      type: String,
+      trim: true,
+      default: '#3B82F6',
+      maxlength: 16
+    },
+    createdAt: {
+      type: Date,
+      default: Date.now
+    }
+  }],
   onboardingStatus: {
     type: String,
     enum: ['pending', 'in_progress', 'completed'],

--- a/routes/circles.js
+++ b/routes/circles.js
@@ -1,0 +1,229 @@
+const express = require('express');
+const router = express.Router();
+const { body, validationResult } = require('express-validator');
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+const Friendship = require('../models/Friendship');
+
+const COLOR_REGEX = /^#[0-9A-Fa-f]{6}$/;
+
+const authenticateToken = (req, res, next) => {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'your-secret-key-change-in-production');
+    req.user = decoded;
+    return next();
+  } catch {
+    return res.status(403).json({ error: 'Invalid or expired token' });
+  }
+};
+
+const normalizeCircleName = (value = '') => value.trim().slice(0, 50);
+
+const findCircleIndex = (circles = [], name = '') => {
+  const normalized = normalizeCircleName(name).toLowerCase();
+  return circles.findIndex((circle) => String(circle.name || '').trim().toLowerCase() === normalized);
+};
+
+router.get('/', authenticateToken, async (req, res) => {
+  try {
+    const user = await User.findById(req.user.userId).select('circles');
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    const circles = Array.isArray(user.circles) ? user.circles : [];
+    const allMemberIds = [...new Set(circles.flatMap((circle) => (circle.members || []).map((member) => String(member))))];
+    const memberUsers = await User.find({ _id: { $in: allMemberIds } }).select('username realName avatarUrl').lean();
+    const memberMap = new Map(memberUsers.map((member) => [String(member._id), member]));
+
+    return res.json({
+      circles: circles.map((circle) => ({
+        name: circle.name,
+        color: circle.color,
+        memberCount: Array.isArray(circle.members) ? circle.members.length : 0,
+        members: (circle.members || [])
+          .map((memberId) => memberMap.get(String(memberId)))
+          .filter(Boolean)
+      }))
+    });
+  } catch (error) {
+    console.error('Get circles error:', error);
+    return res.status(500).json({ error: 'Failed to load circles' });
+  }
+});
+
+router.post('/', [
+  authenticateToken,
+  body('name').isString().trim().isLength({ min: 1, max: 50 }),
+  body('color').optional().isString().trim().matches(COLOR_REGEX)
+], async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const user = await User.findById(req.user.userId);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    const name = normalizeCircleName(req.body.name);
+    if (findCircleIndex(user.circles, name) >= 0) {
+      return res.status(409).json({ error: 'Circle name already exists' });
+    }
+
+    user.circles.push({
+      name,
+      color: req.body.color || '#3B82F6',
+      members: []
+    });
+
+    await user.save();
+    return res.status(201).json({ success: true, message: 'Circle created' });
+  } catch (error) {
+    console.error('Create circle error:', error);
+    return res.status(500).json({ error: 'Failed to create circle' });
+  }
+});
+
+router.put('/:circleName', [
+  authenticateToken,
+  body('name').optional().isString().trim().isLength({ min: 1, max: 50 }),
+  body('color').optional().isString().trim().matches(COLOR_REGEX)
+], async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const user = await User.findById(req.user.userId);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    const index = findCircleIndex(user.circles, req.params.circleName);
+    if (index < 0) {
+      return res.status(404).json({ error: 'Circle not found' });
+    }
+
+    if (req.body.name) {
+      const nextName = normalizeCircleName(req.body.name);
+      const duplicateIndex = findCircleIndex(user.circles, nextName);
+      if (duplicateIndex >= 0 && duplicateIndex !== index) {
+        return res.status(409).json({ error: 'Circle name already exists' });
+      }
+      user.circles[index].name = nextName;
+    }
+
+    if (req.body.color) {
+      user.circles[index].color = req.body.color;
+    }
+
+    await user.save();
+    return res.json({ success: true, message: 'Circle updated' });
+  } catch (error) {
+    console.error('Update circle error:', error);
+    return res.status(500).json({ error: 'Failed to update circle' });
+  }
+});
+
+router.delete('/:circleName', authenticateToken, async (req, res) => {
+  try {
+    const user = await User.findById(req.user.userId);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    const index = findCircleIndex(user.circles, req.params.circleName);
+    if (index < 0) {
+      return res.status(404).json({ error: 'Circle not found' });
+    }
+
+    user.circles.splice(index, 1);
+    await user.save();
+    return res.json({ success: true, message: 'Circle deleted' });
+  } catch (error) {
+    console.error('Delete circle error:', error);
+    return res.status(500).json({ error: 'Failed to delete circle' });
+  }
+});
+
+router.post('/:circleName/members', [
+  authenticateToken,
+  body('userId').isMongoId().withMessage('Valid userId required')
+], async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const ownerId = String(req.user.userId);
+    const memberId = String(req.body.userId);
+
+    const friendship = await Friendship.findOne({
+      $or: [
+        { requester: ownerId, recipient: memberId, status: 'accepted' },
+        { requester: memberId, recipient: ownerId, status: 'accepted' }
+      ]
+    }).lean();
+
+    if (!friendship) {
+      return res.status(403).json({ error: 'Only accepted friends can be added to circles' });
+    }
+
+    const user = await User.findById(ownerId);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    const index = findCircleIndex(user.circles, req.params.circleName);
+    if (index < 0) {
+      return res.status(404).json({ error: 'Circle not found' });
+    }
+
+    const alreadyExists = (user.circles[index].members || []).some((id) => String(id) === memberId);
+    if (!alreadyExists) {
+      user.circles[index].members.push(memberId);
+      await user.save();
+    }
+
+    return res.json({ success: true, message: 'Member added to circle' });
+  } catch (error) {
+    console.error('Add circle member error:', error);
+    return res.status(500).json({ error: 'Failed to add member to circle' });
+  }
+});
+
+router.delete('/:circleName/members/:userId', authenticateToken, async (req, res) => {
+  try {
+    const user = await User.findById(req.user.userId);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    const index = findCircleIndex(user.circles, req.params.circleName);
+    if (index < 0) {
+      return res.status(404).json({ error: 'Circle not found' });
+    }
+
+    user.circles[index].members = (user.circles[index].members || []).filter(
+      (memberId) => String(memberId) !== String(req.params.userId)
+    );
+
+    await user.save();
+    return res.json({ success: true, message: 'Member removed from circle' });
+  } catch (error) {
+    console.error('Remove circle member error:', error);
+    return res.status(500).json({ error: 'Failed to remove member from circle' });
+  }
+});
+
+module.exports = router;

--- a/routes/feed.js
+++ b/routes/feed.js
@@ -4,10 +4,56 @@ const { body, validationResult } = require('express-validator');
 const jwt = require('jsonwebtoken');
 const Post = require('../models/Post');
 const User = require('../models/User');
+const Friendship = require('../models/Friendship');
 
 const MEDIA_URL_MAX_ITEMS = 8;
 const MEDIA_URL_MAX_LENGTH = 2048;
 const HTTP_URL_REGEX = /^https?:\/\/\S+$/i;
+const VALID_VISIBILITY = ['public', 'friends', 'circles', 'specific_users', 'private'];
+
+const parseViewerCoordinates = (req) => {
+  const latitude = Number.parseFloat(req.query.latitude);
+  const longitude = Number.parseFloat(req.query.longitude);
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    return null;
+  }
+  if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+    return null;
+  }
+  return [longitude, latitude];
+};
+
+const getFriendIds = async (userId) => {
+  const friendships = await Friendship.find({
+    status: 'accepted',
+    $or: [
+      { requester: userId },
+      { recipient: userId }
+    ]
+  }).select('requester recipient').lean();
+
+  const ids = new Set();
+  for (const friendship of friendships) {
+    const requester = String(friendship.requester);
+    const recipient = String(friendship.recipient);
+    ids.add(requester === String(userId) ? recipient : requester);
+  }
+  return ids;
+};
+
+const normalizeObjectIdArray = (value) => {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => String(entry || '').trim())
+    .filter(Boolean);
+};
+
+const canViewerSeePost = (post, viewerId, friendIds, viewerCoordinates = null) => {
+  return post.canView(viewerId, {
+    isFriend: friendIds.has(String(post.authorId)),
+    viewerCoordinates
+  });
+};
 
 const sanitizeAndValidateMediaUrls = (mediaUrlsInput) => {
   if (mediaUrlsInput === undefined || mediaUrlsInput === null) {
@@ -115,30 +161,39 @@ const authenticateToken = (req, res, next) => {
 };
 
 // Get user's feed (posts where user is targetFeedId)
-router.get('/:userId', authenticateToken, async (req, res) => {
+router.get('/user/:userId', authenticateToken, async (req, res) => {
   try {
     const { userId } = req.params;
     const page = parseInt(req.query.page) || 1;
     const limit = parseInt(req.query.limit) || 20;
-    const requesterId = String(req.user.userId || '');
-    const targetUserId = String(userId || '');
-    
-    // Check if requesting user has permission to view this feed
-    if (requesterId !== targetUserId) {
-      // In a real implementation, check friendship status
-      const isFriend = false; // Placeholder - implement friendship check
-      if (!isFriend) {
-        return res.status(403).json({ error: 'Cannot view this user\'s feed' });
-      }
-    }
-    
-    const posts = await Post.getUserFeed(userId, page, limit);
+    const viewerId = String(req.user.userId || '');
+    const viewerCoordinates = parseViewerCoordinates(req);
+    const friendIds = await getFriendIds(viewerId);
+
+    const candidatePosts = await Post.find({
+      targetFeedId: userId,
+      $or: [
+        { expiresAt: null },
+        { expiresAt: { $gt: new Date() } }
+      ]
+    })
+      .sort({ createdAt: -1 })
+      .limit(Math.max(limit * 5, 100))
+      .populate('authorId', 'username realName')
+      .populate('targetFeedId', 'username realName');
+
+    const visiblePosts = candidatePosts
+      .filter((post) => canViewerSeePost(post, viewerId, friendIds, viewerCoordinates));
+
+    const start = (page - 1) * limit;
+    const posts = visiblePosts.slice(start, start + limit);
+
     res.json({
       success: true,
       posts,
       page,
       limit,
-      total: posts.length
+      total: visiblePosts.length
     });
   } catch (error) {
     console.error('Error fetching user feed:', error);
@@ -152,8 +207,13 @@ router.post('/post', [
   body('content').optional().trim().isLength({ max: 5000 }).withMessage('Content too long'),
   body('encryptedContent').optional().trim(),
   body('targetFeedId').isMongoId().withMessage('Valid target feed ID required'),
-  body('visibility').optional().isIn(['public', 'friends', 'private']).withMessage('Invalid visibility'),
+  body('visibility').optional().isIn(VALID_VISIBILITY).withMessage('Invalid visibility'),
   body('mediaUrls').optional(),
+  body('visibleToCircles').optional().isArray({ max: 25 }).withMessage('visibleToCircles must be an array'),
+  body('visibleToUsers').optional().isArray({ max: 200 }).withMessage('visibleToUsers must be an array'),
+  body('excludeUsers').optional().isArray({ max: 200 }).withMessage('excludeUsers must be an array'),
+  body('locationRadius').optional({ nullable: true }).isFloat({ min: 1, max: 1000 }),
+  body('expiresAt').optional({ nullable: true }).isISO8601(),
   body('latitude').optional().isFloat({ min: -90, max: 90 }),
   body('longitude').optional().isFloat({ min: -180, max: 180 })
 ], async (req, res) => {
@@ -168,6 +228,11 @@ router.post('/post', [
       encryptedContent,
       targetFeedId,
       visibility = 'public',
+      visibleToCircles,
+      visibleToUsers,
+      excludeUsers,
+      locationRadius,
+      expiresAt,
       latitude,
       longitude,
       mediaUrls: mediaUrlsInput
@@ -191,11 +256,63 @@ router.post('/post', [
     
     // Check permissions (users can post to their own feed or friends' feeds)
     if (normalizedTargetFeedId !== authorId) {
-      // In a real implementation, check if users are friends
-      const areFriends = false; // Placeholder - implement friendship check
-      if (!areFriends) {
+      const friendship = await Friendship.findOne({
+        status: 'accepted',
+        $or: [
+          { requester: authorId, recipient: normalizedTargetFeedId },
+          { requester: normalizedTargetFeedId, recipient: authorId }
+        ]
+      }).lean();
+
+      if (!friendship) {
         return res.status(403).json({ error: 'Cannot post to this user\'s feed' });
       }
+    }
+
+    const normalizedVisibleToCircles = Array.isArray(visibleToCircles)
+      ? [...new Set(visibleToCircles.map((circleName) => String(circleName || '').trim()).filter(Boolean).slice(0, 25))]
+      : [];
+    const normalizedVisibleToUsers = normalizeObjectIdArray(visibleToUsers).slice(0, 200);
+    const normalizedExcludeUsers = normalizeObjectIdArray(excludeUsers).slice(0, 200);
+
+    let effectiveVisibleToUsers = normalizedVisibleToUsers;
+
+    if (visibility === 'circles') {
+      if (normalizedVisibleToCircles.length === 0) {
+        return res.status(400).json({ error: 'visibleToCircles is required for circles visibility' });
+      }
+
+      const authorUser = await User.findById(authorId).select('circles').lean();
+      const allowedSet = new Set(normalizedVisibleToUsers);
+      for (const circleName of normalizedVisibleToCircles) {
+        const circle = (authorUser?.circles || []).find(
+          (entry) => String(entry?.name || '').trim().toLowerCase() === circleName.toLowerCase()
+        );
+        if (circle && Array.isArray(circle.members)) {
+          for (const member of circle.members) {
+            allowedSet.add(String(member));
+          }
+        }
+      }
+      effectiveVisibleToUsers = [...allowedSet];
+    }
+
+    if (visibility === 'specific_users' && effectiveVisibleToUsers.length === 0) {
+      return res.status(400).json({ error: 'visibleToUsers is required for specific_users visibility' });
+    }
+
+    if (effectiveVisibleToUsers.length > 0 && normalizedExcludeUsers.length > 0) {
+      const excluded = new Set(normalizedExcludeUsers);
+      effectiveVisibleToUsers = effectiveVisibleToUsers.filter((entry) => !excluded.has(entry));
+    }
+
+    let normalizedExpiresAt = null;
+    if (expiresAt) {
+      const parsed = new Date(expiresAt);
+      if (Number.isNaN(parsed.getTime()) || parsed.getTime() <= Date.now()) {
+        return res.status(400).json({ error: 'expiresAt must be a future timestamp' });
+      }
+      normalizedExpiresAt = parsed;
     }
     
     const postData = {
@@ -205,6 +322,11 @@ router.post('/post', [
       encryptedContent,
       isEncrypted: !!encryptedContent,
       visibility,
+      visibleToCircles: normalizedVisibleToCircles,
+      visibleToUsers: effectiveVisibleToUsers,
+      excludeUsers: normalizedExcludeUsers,
+      locationRadius: Number.isFinite(Number(locationRadius)) ? Number(locationRadius) : null,
+      expiresAt: normalizedExpiresAt,
       mediaUrls: mediaUrlsValidation.mediaUrls
     };
     
@@ -274,7 +396,8 @@ router.post('/post/:postId/like', authenticateToken, async (req, res) => {
     }
     
     // Check if user can view post before liking
-    const canView = post.canView(userId, false); // Pass false for isFriend placeholder
+    const friendIds = await getFriendIds(String(userId));
+    const canView = canViewerSeePost(post, String(userId), friendIds, null);
     if (!canView) {
       return res.status(403).json({ error: 'Cannot like this post' });
     }
@@ -337,7 +460,8 @@ router.post('/post/:postId/comment', [
     }
     
     // Check if user can view post before commenting
-    const canView = post.canView(userId, false); // Pass false for isFriend placeholder
+    const friendIds = await getFriendIds(String(userId));
+    const canView = canViewerSeePost(post, String(userId), friendIds, null);
     if (!canView) {
       return res.status(403).json({ error: 'Cannot comment on this post' });
     }
@@ -362,36 +486,48 @@ router.post('/post/:postId/comment', [
 // Get personalized timeline (posts from user and friends)
 router.get('/timeline', authenticateToken, async (req, res) => {
   try {
-    const userId = req.user.userId;
+    const userId = String(req.user.userId);
     const page = parseInt(req.query.page) || 1;
     const limit = parseInt(req.query.limit) || 20;
-    
-    // In a real implementation, you would:
-    // 1. Get user's friends list
-    // 2. Query posts where authorId is in friends list OR authorId is user
-    // 3. Apply visibility filters
-    
-    // For now, return posts where user is author or target
-    const posts = await Post.find({
-      $or: [
-        { authorId: userId },
-        { targetFeedId: userId }
-      ],
-      visibility: { $in: ['public', 'friends'] }
+    const viewerCoordinates = parseViewerCoordinates(req);
+    const friendIds = await getFriendIds(userId);
+    const authorIds = [userId, ...friendIds];
+
+    const candidatePosts = await Post.find({
+      $and: [
+        {
+          $or: [
+            { authorId: { $in: authorIds } },
+            { targetFeedId: userId },
+            { visibility: 'public' },
+            { visibleToUsers: userId }
+          ]
+        },
+        {
+          $or: [
+            { expiresAt: null },
+            { expiresAt: { $gt: new Date() } }
+          ]
+        }
+      ]
     })
-    .sort({ createdAt: -1 })
-    .skip((page - 1) * limit)
-    .limit(limit)
-    .populate('authorId', 'username realName')
-    .populate('targetFeedId', 'username realName')
-    .lean();
+      .sort({ createdAt: -1 })
+      .limit(Math.max(limit * 5, 100))
+      .populate('authorId', 'username realName')
+      .populate('targetFeedId', 'username realName');
+
+    const visiblePosts = candidatePosts
+      .filter((post) => canViewerSeePost(post, userId, friendIds, viewerCoordinates));
+
+    const start = (page - 1) * limit;
+    const posts = visiblePosts.slice(start, start + limit);
     
     res.json({
       success: true,
       posts,
       page,
       limit,
-      total: posts.length
+      total: visiblePosts.length
     });
   } catch (error) {
     console.error('Error fetching timeline:', error);
@@ -416,7 +552,8 @@ router.get('/post/:postId', authenticateToken, async (req, res) => {
     }
     
     // Check if user can view post
-    const canView = post.canView(userId, false); // Pass false for isFriend placeholder
+    const friendIds = await getFriendIds(String(userId));
+    const canView = canViewerSeePost(post, String(userId), friendIds, null);
     if (!canView) {
       return res.status(403).json({ error: 'Cannot view this post' });
     }

--- a/routes/public.js
+++ b/routes/public.js
@@ -68,7 +68,11 @@ const findUserByIdOrUsername = async (identifier) => {
 
 const publicPostQuery = (userId) => ({
   targetFeedId: userId,
-  visibility: 'public'
+  visibility: 'public',
+  $or: [
+    { expiresAt: null },
+    { expiresAt: { $gt: new Date() } }
+  ]
 });
 
 const publicPostPopulate = [
@@ -113,6 +117,9 @@ const toPublicPost = (post) => ({
   content: post.content || null,
   mediaUrls: normalizeMediaUrls(post.mediaUrls),
   visibility: post.visibility,
+  visibleToCircles: Array.isArray(post.visibleToCircles) ? post.visibleToCircles : [],
+  locationRadius: Number.isFinite(Number(post.locationRadius)) ? Number(post.locationRadius) : null,
+  expiresAt: post.expiresAt || null,
   likesCount: Array.isArray(post.likes) ? post.likes.length : 0,
   commentsCount: Array.isArray(post.comments) ? post.comments.length : 0,
   createdAt: post.createdAt,
@@ -158,7 +165,7 @@ router.get('/users/:userId/feed', async (req, res) => {
         .sort({ createdAt: -1 })
         .skip(skip)
         .limit(limit)
-        .select('_id authorId targetFeedId content visibility mediaUrls likes comments createdAt updatedAt')
+        .select('_id authorId targetFeedId content visibility visibleToCircles locationRadius expiresAt mediaUrls likes comments createdAt updatedAt')
         .populate(publicPostPopulate)
         .lean(),
       Post.countDocuments(query)

--- a/server.js
+++ b/server.js
@@ -152,6 +152,7 @@ registerRoute('/api/market', () => require('./routes/market'));
 registerRoute('/api/location', () => require('./routes/location'));
 registerRoute('/api/universal', () => require('./routes/universal'));
 registerRoute('/api/friends', () => require('./routes/friends'));
+registerRoute('/api/circles', () => require('./routes/circles'));
 
 let newsRoutes = null;
 let mapsRoutes = null;


### PR DESCRIPTION
## Summary
Implements Issue #7 with circles, granular post visibility controls, exclusions, location radius, expiration, and feed privacy enforcement.

## Backend
- Added outes/circles.js (CRUD + membership management)
- Added User.circles field in models/User.js
- Extended models/Post.js:
  - isibility: public|friends|circles|specific_users|private
  - isibleToCircles, isibleToUsers, excludeUsers, locationRadius, expiresAt
  - enhanced canView() with exclusions, expiration, friend checks, location checks
- Updated outes/feed.js:
  - server-side friend resolution via accepted friendships
  - create-post support for circles/specific users/exclusions/radius/expiration
  - privacy-aware filtering on user feed, timeline, likes/comments, single-post fetch
- Updated outes/public.js to exclude expired public posts and expose privacy indicator fields
- Mounted circles route in server.js

## Frontend
- Added rontend/src/components/PrivacySelector.js
- Added rontend/src/components/CircleManager.js
- Updated rontend/src/pages/Social.js:
  - privacy selector in post creation
  - circles manager UI
  - privacy badges/indicators on posts
- Updated rontend/src/utils/api.js:
  - circlesAPI
  - updated user feed endpoint path

## Validation
- Static diagnostics on all edited files: no errors.
- Node/npm runtime tests unavailable in this shell environment.

Closes #7