### PR TITLE
feat(moderation): User Moderation Tools (#8)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,7 @@ import News from './pages/News';
 import Maps from './pages/Maps';
 import OnboardingPage from './pages/OnboardingPage';
 import SecurityCenter from './pages/SecurityCenter';
+import ModerationDashboard from './pages/ModerationDashboard';
 import { authAPI } from './utils/api';
 
 const ProtectedRoute = ({
@@ -244,6 +245,7 @@ function App() {
               {isAuthenticated && !encryptionPasswordRequired && !onboardingRequired && <Link to="/news" className="text-gray-600 hover:text-blue-600">News</Link>}
               {isAuthenticated && !encryptionPasswordRequired && !onboardingRequired && <Link to="/maps" className="text-gray-600 hover:text-blue-600">Maps</Link>}
               {isAuthenticated && !encryptionPasswordRequired && !onboardingRequired && <Link to="/security" className="text-gray-600 hover:text-blue-600">Security</Link>}
+              {isAuthenticated && user?.isAdmin && !encryptionPasswordRequired && !onboardingRequired && <Link to="/moderation" className="text-gray-600 hover:text-blue-600">Moderation</Link>}
               {isAuthenticated && !encryptionPasswordRequired && !onboardingRequired && <Link to="/refer" className="text-gray-600 hover:text-blue-600">Refer Friend</Link>}
               {isAuthenticated && onboardingRequired && <Link to="/onboarding" className="text-blue-600 font-medium">Onboarding</Link>}
               {isAuthenticated ? (
@@ -346,6 +348,20 @@ function App() {
                   allowWhenEncryptionRequired={false}
                 >
                   <SecurityCenter />
+                </ProtectedRoute>
+              )}
+            />
+            <Route
+              path="/moderation"
+              element={(
+                <ProtectedRoute
+                  isAuthenticated={isAuthenticated}
+                  onboardingRequired={onboardingRequired}
+                  allowWhenOnboardingRequired={false}
+                  encryptionPasswordRequired={encryptionPasswordRequired}
+                  allowWhenEncryptionRequired={false}
+                >
+                  {user?.isAdmin ? <ModerationDashboard /> : <Navigate to="/social" replace />}
                 </ProtectedRoute>
               )}
             />

--- a/frontend/src/components/BlockButton.js
+++ b/frontend/src/components/BlockButton.js
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+
+function BlockButton({ isBlocked, onBlock, onUnblock }) {
+  const [busy, setBusy] = useState(false);
+
+  const handleClick = async () => {
+    setBusy(true);
+    try {
+      if (isBlocked) {
+        await onUnblock();
+      } else {
+        const reason = window.prompt('Optional reason for blocking this user:', '') || '';
+        await onBlock(reason);
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={busy}
+      className={`px-3 py-1.5 rounded border text-sm ${isBlocked ? 'border-green-600 text-green-700' : 'border-red-600 text-red-700'} disabled:opacity-60`}
+    >
+      {busy ? 'Saving...' : isBlocked ? 'Unblock User' : 'Block User'}
+    </button>
+  );
+}
+
+export default BlockButton;

--- a/frontend/src/components/ReportModal.js
+++ b/frontend/src/components/ReportModal.js
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+
+const CATEGORIES = [
+  'spam',
+  'harassment',
+  'hate_speech',
+  'misinformation',
+  'illegal_content',
+  'self_harm',
+  'other'
+];
+
+function ReportModal({ isOpen, targetType, targetId, targetUserId, onClose, onSubmit }) {
+  const [category, setCategory] = useState('spam');
+  const [description, setDescription] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setSubmitting(true);
+    await onSubmit({
+      targetType,
+      targetId,
+      targetUserId,
+      category,
+      description: description.trim()
+    });
+    setSubmitting(false);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-md bg-white rounded-lg shadow-lg p-5 space-y-3">
+        <h3 className="text-lg font-semibold text-gray-900">Report Content</h3>
+        <p className="text-sm text-gray-600">Help keep the community safe by reporting violations.</p>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Category</label>
+          <select value={category} onChange={(e) => setCategory(e.target.value)} className="w-full border rounded p-2">
+            {CATEGORIES.map((item) => (
+              <option key={item} value={item}>{item.replaceAll('_', ' ')}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className="w-full border rounded p-2"
+            rows={4}
+            maxLength={1000}
+            placeholder="Provide context for moderators"
+          />
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="px-3 py-2 rounded border border-gray-300">
+            Cancel
+          </button>
+          <button type="submit" disabled={submitting} className="px-3 py-2 rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-60">
+            {submitting ? 'Submitting...' : 'Submit Report'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default ReportModal;

--- a/frontend/src/pages/ModerationDashboard.js
+++ b/frontend/src/pages/ModerationDashboard.js
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { moderationAPI } from '../utils/api';
+
+function ModerationDashboard() {
+  const [reports, setReports] = useState([]);
+  const [appeals, setAppeals] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadData = async () => {
+    setLoading(true);
+    try {
+      const [reportsRes, appealsRes] = await Promise.all([
+        moderationAPI.getReports({ page: 1, limit: 50 }),
+        moderationAPI.getAppeals()
+      ]);
+      setReports(Array.isArray(reportsRes.data?.reports) ? reportsRes.data.reports : []);
+      setAppeals(Array.isArray(appealsRes.data?.appeals) ? appealsRes.data.appeals : []);
+    } catch (error) {
+      toast.error(error.response?.data?.error || 'Failed to load moderation data');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const updateReportStatus = async (reportId, status) => {
+    try {
+      await moderationAPI.updateReport(reportId, { status });
+      await loadData();
+      toast.success('Report updated');
+    } catch (error) {
+      toast.error(error.response?.data?.error || 'Failed to update report');
+    }
+  };
+
+  const processAppeal = async (reportId, status) => {
+    try {
+      await moderationAPI.processAppeal(reportId, { status, decision: `Appeal ${status}` });
+      await loadData();
+      toast.success('Appeal processed');
+    } catch (error) {
+      toast.error(error.response?.data?.error || 'Failed to process appeal');
+    }
+  };
+
+  if (loading) {
+    return <div className="min-h-screen grid place-items-center">Loading moderation dashboard...</div>;
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto p-4 md:p-6 space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900">Moderation Dashboard</h1>
+
+      <section className="bg-white rounded-lg shadow-md p-4 space-y-3">
+        <h2 className="text-lg font-semibold">Reports Queue</h2>
+        {reports.map((report) => (
+          <div key={report._id} className="border rounded p-3 flex items-center justify-between">
+            <div>
+              <p className="font-medium text-gray-900">{report.category} • {report.targetType}</p>
+              <p className="text-sm text-gray-500">Status: {report.status} • Priority: {report.priority}</p>
+              <p className="text-sm text-gray-500">Reported by: {report.reporterId?.username || 'unknown'}</p>
+            </div>
+            <div className="flex gap-2">
+              <button onClick={() => updateReportStatus(report._id, 'under_review')} className="px-2 py-1 rounded bg-yellow-100 text-yellow-800 text-sm">Review</button>
+              <button onClick={() => updateReportStatus(report._id, 'resolved')} className="px-2 py-1 rounded bg-green-100 text-green-800 text-sm">Resolve</button>
+              <button onClick={() => updateReportStatus(report._id, 'dismissed')} className="px-2 py-1 rounded bg-gray-100 text-gray-800 text-sm">Dismiss</button>
+            </div>
+          </div>
+        ))}
+        {reports.length === 0 && <p className="text-sm text-gray-500">No reports available.</p>}
+      </section>
+
+      <section className="bg-white rounded-lg shadow-md p-4 space-y-3">
+        <h2 className="text-lg font-semibold">Appeals Queue</h2>
+        {appeals.map((appeal) => (
+          <div key={appeal._id} className="border rounded p-3 flex items-center justify-between">
+            <div>
+              <p className="font-medium text-gray-900">Appeal for report {appeal._id}</p>
+              <p className="text-sm text-gray-500">By: {appeal.targetUserId?.username || appeal.reporterId?.username || 'unknown'}</p>
+              <p className="text-sm text-gray-500">{appeal.appeal?.justification || ''}</p>
+            </div>
+            <div className="flex gap-2">
+              <button onClick={() => processAppeal(appeal._id, 'approved')} className="px-2 py-1 rounded bg-green-100 text-green-800 text-sm">Approve</button>
+              <button onClick={() => processAppeal(appeal._id, 'rejected')} className="px-2 py-1 rounded bg-red-100 text-red-800 text-sm">Reject</button>
+            </div>
+          </div>
+        ))}
+        {appeals.length === 0 && <p className="text-sm text-gray-500">No pending appeals.</p>}
+      </section>
+    </div>
+  );
+}
+
+export default ModerationDashboard;

--- a/frontend/src/pages/Social.js
+++ b/frontend/src/pages/Social.js
@@ -1,8 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { authAPI, circlesAPI, feedAPI, friendsAPI, galleryAPI } from '../utils/api';
+import { authAPI, circlesAPI, feedAPI, friendsAPI, galleryAPI, moderationAPI } from '../utils/api';
 import PrivacySelector from '../components/PrivacySelector';
 import CircleManager from '../components/CircleManager';
+import ReportModal from '../components/ReportModal';
+import BlockButton from '../components/BlockButton';
 
 const MEDIA_URL_MAX_ITEMS = 8;
 const MEDIA_URL_MAX_LENGTH = 2048;
@@ -173,6 +175,15 @@ const Social = () => {
   const [galleryLoading, setGalleryLoading] = useState(false);
   const [galleryActionLoadingByImage, setGalleryActionLoadingByImage] = useState({});
   const [galleryEditById, setGalleryEditById] = useState({});
+  const [blockedUserIds, setBlockedUserIds] = useState([]);
+  const [mutedUserIds, setMutedUserIds] = useState([]);
+  const [myReports, setMyReports] = useState([]);
+  const [reportModalState, setReportModalState] = useState({
+    isOpen: false,
+    targetType: 'post',
+    targetId: null,
+    targetUserId: null
+  });
 
   const galleryOwnerIdentifier = useMemo(() => {
     if (galleryTarget) {
@@ -257,6 +268,16 @@ const Social = () => {
     ]);
     setCircles(Array.isArray(circlesResponse.data?.circles) ? circlesResponse.data.circles : []);
     setFriends(Array.isArray(friendsResponse.data?.friends) ? friendsResponse.data.friends : []);
+
+    const [blocksResponse, mutesResponse, reportsResponse] = await Promise.all([
+      moderationAPI.getBlocks().catch(() => ({ data: { blockedUsers: [] } })),
+      moderationAPI.getMutes().catch(() => ({ data: { mutedUsers: [] } })),
+      moderationAPI.getMyReports().catch(() => ({ data: { reports: [] } }))
+    ]);
+
+    setBlockedUserIds((blocksResponse.data?.blockedUsers || []).map((entry) => String(entry._id)));
+    setMutedUserIds((mutesResponse.data?.mutedUsers || []).map((entry) => String(entry._id)));
+    setMyReports(Array.isArray(reportsResponse.data?.reports) ? reportsResponse.data.reports : []);
 
     const timelineResponse = await feedAPI.getTimeline();
     const timelinePosts = Array.isArray(timelineResponse.data?.posts)
@@ -430,6 +451,80 @@ const Social = () => {
       await refreshCircles();
     } catch (error) {
       setFeedError(error.response?.data?.error || 'Failed to remove circle member.');
+    }
+  };
+
+  const refreshModerationState = async () => {
+    const [blocksResponse, mutesResponse, reportsResponse] = await Promise.all([
+      moderationAPI.getBlocks().catch(() => ({ data: { blockedUsers: [] } })),
+      moderationAPI.getMutes().catch(() => ({ data: { mutedUsers: [] } })),
+      moderationAPI.getMyReports().catch(() => ({ data: { reports: [] } }))
+    ]);
+
+    setBlockedUserIds((blocksResponse.data?.blockedUsers || []).map((entry) => String(entry._id)));
+    setMutedUserIds((mutesResponse.data?.mutedUsers || []).map((entry) => String(entry._id)));
+    setMyReports(Array.isArray(reportsResponse.data?.reports) ? reportsResponse.data.reports : []);
+  };
+
+  const handleBlockUser = async (userId, reason = '') => {
+    try {
+      await moderationAPI.blockUser(userId, reason);
+      await refreshModerationState();
+      await loadFeed();
+    } catch (error) {
+      setFeedError(error.response?.data?.error || 'Failed to block user.');
+    }
+  };
+
+  const handleUnblockUser = async (userId) => {
+    try {
+      await moderationAPI.unblockUser(userId);
+      await refreshModerationState();
+      await loadFeed();
+    } catch (error) {
+      setFeedError(error.response?.data?.error || 'Failed to unblock user.');
+    }
+  };
+
+  const handleToggleMuteUser = async (userId) => {
+    try {
+      if (mutedUserIds.includes(String(userId))) {
+        await moderationAPI.unmuteUser(userId);
+      } else {
+        await moderationAPI.muteUser(userId);
+      }
+      await refreshModerationState();
+      await loadFeed();
+    } catch (error) {
+      setFeedError(error.response?.data?.error || 'Failed to update mute state.');
+    }
+  };
+
+  const openReportModal = (targetType, targetId, targetUserId) => {
+    setReportModalState({
+      isOpen: true,
+      targetType,
+      targetId,
+      targetUserId
+    });
+  };
+
+  const closeReportModal = () => {
+    setReportModalState({
+      isOpen: false,
+      targetType: 'post',
+      targetId: null,
+      targetUserId: null
+    });
+  };
+
+  const submitReport = async (payload) => {
+    try {
+      await moderationAPI.report(payload);
+      await refreshModerationState();
+      closeReportModal();
+    } catch (error) {
+      setFeedError(error.response?.data?.error || 'Failed to submit report.');
     }
   };
 
@@ -968,9 +1063,12 @@ const Social = () => {
             ) : (
               posts.map((post) => {
                 const postAuthor = post.authorId?.username || 'unknown';
+                const postAuthorId = String(post.authorId?._id || post.authorId || '');
                 const postTarget = post.targetFeedId?.username || postAuthor;
                 const hasLiked = currentUser ? post.likes.includes(currentUser._id) : false;
                 const postBusy = Boolean(actionLoadingByPost[post._id]);
+                const isBlocked = blockedUserIds.includes(postAuthorId);
+                const isMuted = mutedUserIds.includes(postAuthorId);
 
                 return (
                   <article key={post._id} className="bg-white rounded-xl shadow p-5 space-y-3 border border-gray-100">
@@ -1014,6 +1112,51 @@ const Social = () => {
                       <span>{post.likesCount} like{post.likesCount === 1 ? '' : 's'}</span>
                       <span>{post.commentsCount} comment{post.commentsCount === 1 ? '' : 's'}</span>
                     </div>
+
+                    {isAuthenticated && postAuthorId && postAuthorId !== String(currentUser?._id) && (
+                      <div className="flex flex-wrap gap-2">
+                        <BlockButton
+                          isBlocked={isBlocked}
+                          onBlock={(reason) => handleBlockUser(postAuthorId, reason)}
+                          onUnblock={() => handleUnblockUser(postAuthorId)}
+                        />
+                        <button
+                          type="button"
+                          onClick={() => handleToggleMuteUser(postAuthorId)}
+                          className="px-3 py-1.5 rounded border border-gray-400 text-sm"
+                        >
+                          {isMuted ? 'Unmute User' : 'Mute User'}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => openReportModal('post', post._id, postAuthorId)}
+                          className="px-3 py-1.5 rounded border border-red-300 text-red-700 text-sm"
+                        >
+                          Report
+                        </button>
+                      </div>
+                    )}
+
+          {isAuthenticated && (
+            <section className="bg-white rounded-xl shadow p-5 border border-gray-100 space-y-3">
+              <h3 className="text-lg font-semibold">Moderation Transparency</h3>
+              <p className="text-sm text-gray-600">Track the current status of your submitted reports.</p>
+              {myReports.length === 0 ? (
+                <p className="text-sm text-gray-500">No submitted reports yet.</p>
+              ) : (
+                <div className="space-y-2">
+                  {myReports.slice(0, 10).map((report) => (
+                    <div key={report.id} className="border rounded p-2 text-sm">
+                      <p className="font-medium text-gray-900">
+                        {report.category} • {report.targetType} • {report.status}
+                      </p>
+                      <p className="text-gray-500">{formatDate(report.createdAt)}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+          )}
 
                     {isAuthenticated ? (
                       <div className="space-y-3">
@@ -1337,6 +1480,15 @@ const Social = () => {
           </section>
         </aside>
       </div>
+
+      <ReportModal
+        isOpen={reportModalState.isOpen}
+        targetType={reportModalState.targetType}
+        targetId={reportModalState.targetId}
+        targetUserId={reportModalState.targetUserId}
+        onClose={closeReportModal}
+        onSubmit={submitReport}
+      />
     </div>
   );
 };

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -313,4 +313,22 @@ export const mapsAPI = {
   getCommunityMap: (params) => api.get('/maps/community', { params }),
 };
 
+export const moderationAPI = {
+  report: (data) => api.post('/moderation/report', data),
+  getMyReports: () => api.get('/moderation/my-reports'),
+  getAccountActions: () => api.get('/moderation/account-actions'),
+  getBlocks: () => api.get('/moderation/blocks'),
+  blockUser: (userId, reason = '') => api.post('/moderation/block', { userId, reason }),
+  unblockUser: (userId) => api.delete(`/moderation/block/${encodeURIComponent(userId)}`),
+  getMutes: () => api.get('/moderation/mutes'),
+  muteUser: (userId) => api.post('/moderation/mute', { userId }),
+  unmuteUser: (userId) => api.delete(`/moderation/mute/${encodeURIComponent(userId)}`),
+  getReports: (params = {}) => api.get('/moderation/reports', { params }),
+  updateReport: (reportId, data) => api.put(`/moderation/reports/${encodeURIComponent(reportId)}`, data),
+  applyAction: (data) => api.post('/moderation/actions', data),
+  submitAppeal: (data) => api.post('/moderation/appeals', data),
+  getAppeals: () => api.get('/moderation/appeals'),
+  processAppeal: (reportId, data) => api.put(`/moderation/appeals/${encodeURIComponent(reportId)}`, data)
+};
+
 export default api;

--- a/models/BlockList.js
+++ b/models/BlockList.js
@@ -1,0 +1,31 @@
+const mongoose = require('mongoose');
+
+const blockListSchema = new mongoose.Schema({
+  userId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true
+  },
+  blockedUserId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true
+  },
+  reason: {
+    type: String,
+    maxlength: 200,
+    default: ''
+  },
+  expiresAt: {
+    type: Date,
+    default: null
+  }
+}, {
+  timestamps: { createdAt: true, updatedAt: true }
+});
+
+blockListSchema.index({ userId: 1, blockedUserId: 1 }, { unique: true });
+
+module.exports = mongoose.model('BlockList', blockListSchema);

--- a/models/MuteList.js
+++ b/models/MuteList.js
@@ -1,0 +1,26 @@
+const mongoose = require('mongoose');
+
+const muteListSchema = new mongoose.Schema({
+  userId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true
+  },
+  mutedUserId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true
+  },
+  expiresAt: {
+    type: Date,
+    default: null
+  }
+}, {
+  timestamps: { createdAt: true, updatedAt: true }
+});
+
+muteListSchema.index({ userId: 1, mutedUserId: 1 }, { unique: true });
+
+module.exports = mongoose.model('MuteList', muteListSchema);

--- a/models/Report.js
+++ b/models/Report.js
@@ -1,0 +1,104 @@
+const mongoose = require('mongoose');
+
+const reportSchema = new mongoose.Schema({
+  reporterId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true
+  },
+  targetType: {
+    type: String,
+    enum: ['post', 'comment', 'user', 'message'],
+    required: true
+  },
+  targetId: {
+    type: mongoose.Schema.Types.ObjectId,
+    required: true,
+    index: true
+  },
+  targetUserId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true
+  },
+  category: {
+    type: String,
+    enum: ['spam', 'harassment', 'hate_speech', 'misinformation', 'illegal_content', 'self_harm', 'other'],
+    required: true
+  },
+  description: {
+    type: String,
+    default: '',
+    maxlength: 1000
+  },
+  status: {
+    type: String,
+    enum: ['pending', 'under_review', 'resolved', 'dismissed'],
+    default: 'pending',
+    index: true
+  },
+  resolution: {
+    action: {
+      type: String,
+      enum: ['none', 'warning', 'content_removed', 'suspension', 'ban'],
+      default: 'none'
+    },
+    reason: {
+      type: String,
+      default: ''
+    },
+    resolvedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      default: null
+    },
+    resolvedAt: {
+      type: Date,
+      default: null
+    }
+  },
+  priority: {
+    type: String,
+    enum: ['low', 'medium', 'high', 'critical'],
+    default: 'medium'
+  },
+  isAutoHidden: {
+    type: Boolean,
+    default: false
+  },
+  appeal: {
+    status: {
+      type: String,
+      enum: ['none', 'pending', 'approved', 'rejected'],
+      default: 'none'
+    },
+    justification: {
+      type: String,
+      default: '',
+      maxlength: 1500
+    },
+    reviewedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      default: null
+    },
+    reviewedAt: {
+      type: Date,
+      default: null
+    },
+    decision: {
+      type: String,
+      default: ''
+    }
+  }
+}, {
+  timestamps: { createdAt: true, updatedAt: true }
+});
+
+reportSchema.index({ reporterId: 1, createdAt: -1 });
+reportSchema.index({ targetType: 1, targetId: 1, createdAt: -1 });
+reportSchema.index({ status: 1, priority: 1, createdAt: -1 });
+
+module.exports = mongoose.model('Report', reportSchema);

--- a/models/User.js
+++ b/models/User.js
@@ -205,6 +205,42 @@ const userSchema = new mongoose.Schema({
     min: 0,
     max: 100
   },
+  moderationStatus: {
+    type: String,
+    enum: ['active', 'warned', 'suspended', 'banned'],
+    default: 'active'
+  },
+  moderationHistory: [{
+    action: {
+      type: String,
+      enum: ['warning', 'suspension', 'ban']
+    },
+    reason: {
+      type: String,
+      default: ''
+    },
+    duration: {
+      type: Number,
+      default: null
+    },
+    appliedAt: {
+      type: Date,
+      default: Date.now
+    },
+    expiresAt: {
+      type: Date,
+      default: null
+    },
+    appliedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      default: null
+    }
+  }],
+  isAdmin: {
+    type: Boolean,
+    default: false
+  },
   // Friend count (cached for performance)
   friendCount: {
     type: Number,
@@ -278,6 +314,8 @@ userSchema.methods.toPublicProfile = function() {
     registrationStatus: this.registrationStatus,
     hasPGP: !!this.pgpPublicKey,
     hasEncryptionPassword,
+    isAdmin: !!this.isAdmin,
+    moderationStatus: this.moderationStatus || 'active',
     onboardingStatus: this.onboardingStatus || 'pending',
     onboardingStep: this.onboardingStep || 1,
     securityPreferences: this.securityPreferences || {

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -6,6 +6,7 @@ const ChatRoom = require('../models/ChatRoom');
 const ChatMessage = require('../models/ChatMessage');
 const DeviceKey = require('../models/DeviceKey');
 const SecurityEvent = require('../models/SecurityEvent');
+const BlockList = require('../models/BlockList');
 const RoomKeyPackage = require('../models/RoomKeyPackage');
 const User = require('../models/User');
 
@@ -485,6 +486,20 @@ router.post('/rooms/:roomId/messages', [
     if (!user) {
       return res.status(404).json({ error: 'User not found' });
     }
+
+    const memberIds = Array.isArray(room.members)
+      ? room.members.map((member) => String(member))
+      : [];
+    const blockedRelation = await BlockList.findOne({
+      $or: [
+        { userId, blockedUserId: { $in: memberIds } },
+        { userId: { $in: memberIds }, blockedUserId: userId }
+      ]
+    }).select('_id').lean();
+
+    if (blockedRelation) {
+      return res.status(403).json({ error: 'Cannot send messages due to block settings in this room' });
+    }
     
     // Check rate limit for non-resident cities
     const userCity = user.city || '';
@@ -592,6 +607,20 @@ router.post('/rooms/:roomId/messages/e2ee', [
     const user = await User.findById(userId);
     if (!user) {
       return res.status(404).json({ error: 'User not found' });
+    }
+
+    const memberIds = Array.isArray(room.members)
+      ? room.members.map((member) => String(member))
+      : [];
+    const blockedRelation = await BlockList.findOne({
+      $or: [
+        { userId, blockedUserId: { $in: memberIds } },
+        { userId: { $in: memberIds }, blockedUserId: userId }
+      ]
+    }).select('_id').lean();
+
+    if (blockedRelation) {
+      return res.status(403).json({ error: 'Cannot send messages due to block settings in this room' });
     }
 
     const ownedDevice = await DeviceKey.findOne({

--- a/routes/feed.js
+++ b/routes/feed.js
@@ -5,6 +5,8 @@ const jwt = require('jsonwebtoken');
 const Post = require('../models/Post');
 const User = require('../models/User');
 const Friendship = require('../models/Friendship');
+const BlockList = require('../models/BlockList');
+const MuteList = require('../models/MuteList');
 
 const MEDIA_URL_MAX_ITEMS = 8;
 const MEDIA_URL_MAX_LENGTH = 2048;
@@ -39,6 +41,20 @@ const getFriendIds = async (userId) => {
     ids.add(requester === String(userId) ? recipient : requester);
   }
   return ids;
+};
+
+const getBlockedOrMutedIds = async (viewerId) => {
+  const [blocks, blockedByOthers, mutes] = await Promise.all([
+    BlockList.find({ userId: viewerId }).select('blockedUserId').lean(),
+    BlockList.find({ blockedUserId: viewerId }).select('userId').lean(),
+    MuteList.find({ userId: viewerId }).select('mutedUserId').lean()
+  ]);
+
+  const blockedOrMuted = new Set();
+  for (const row of blocks) blockedOrMuted.add(String(row.blockedUserId));
+  for (const row of blockedByOthers) blockedOrMuted.add(String(row.userId));
+  for (const row of mutes) blockedOrMuted.add(String(row.mutedUserId));
+  return blockedOrMuted;
 };
 
 const normalizeObjectIdArray = (value) => {
@@ -169,6 +185,7 @@ router.get('/user/:userId', authenticateToken, async (req, res) => {
     const viewerId = String(req.user.userId || '');
     const viewerCoordinates = parseViewerCoordinates(req);
     const friendIds = await getFriendIds(viewerId);
+    const blockedOrMuted = await getBlockedOrMutedIds(viewerId);
 
     const candidatePosts = await Post.find({
       targetFeedId: userId,
@@ -183,6 +200,8 @@ router.get('/user/:userId', authenticateToken, async (req, res) => {
       .populate('targetFeedId', 'username realName');
 
     const visiblePosts = candidatePosts
+      .filter((post) => !blockedOrMuted.has(String(post.authorId?._id || post.authorId)))
+      .filter((post) => !blockedOrMuted.has(String(post.targetFeedId?._id || post.targetFeedId)))
       .filter((post) => canViewerSeePost(post, viewerId, friendIds, viewerCoordinates));
 
     const start = (page - 1) * limit;
@@ -239,6 +258,17 @@ router.post('/post', [
     } = req.body;
     const authorId = String(req.user.userId || '');
     const normalizedTargetFeedId = String(targetFeedId || '');
+
+    const blockRelation = await BlockList.findOne({
+      $or: [
+        { userId: authorId, blockedUserId: normalizedTargetFeedId },
+        { userId: normalizedTargetFeedId, blockedUserId: authorId }
+      ]
+    }).select('_id').lean();
+
+    if (blockRelation) {
+      return res.status(403).json({ error: 'Cannot interact with this user due to block settings' });
+    }
 
     const mediaUrlsValidation = sanitizeAndValidateMediaUrls(mediaUrlsInput);
     if (!mediaUrlsValidation.ok) {
@@ -491,6 +521,7 @@ router.get('/timeline', authenticateToken, async (req, res) => {
     const limit = parseInt(req.query.limit) || 20;
     const viewerCoordinates = parseViewerCoordinates(req);
     const friendIds = await getFriendIds(userId);
+    const blockedOrMuted = await getBlockedOrMutedIds(userId);
     const authorIds = [userId, ...friendIds];
 
     const candidatePosts = await Post.find({
@@ -517,6 +548,8 @@ router.get('/timeline', authenticateToken, async (req, res) => {
       .populate('targetFeedId', 'username realName');
 
     const visiblePosts = candidatePosts
+      .filter((post) => !blockedOrMuted.has(String(post.authorId?._id || post.authorId)))
+      .filter((post) => !blockedOrMuted.has(String(post.targetFeedId?._id || post.targetFeedId)))
       .filter((post) => canViewerSeePost(post, userId, friendIds, viewerCoordinates));
 
     const start = (page - 1) * limit;

--- a/routes/moderation.js
+++ b/routes/moderation.js
@@ -1,0 +1,473 @@
+const express = require('express');
+const router = express.Router();
+const { body, validationResult } = require('express-validator');
+const jwt = require('jsonwebtoken');
+const Report = require('../models/Report');
+const BlockList = require('../models/BlockList');
+const MuteList = require('../models/MuteList');
+const User = require('../models/User');
+const Post = require('../models/Post');
+
+const REPORT_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const REPORT_LIMIT_MAX = 5;
+
+const authenticateToken = async (req, res, next) => {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'your-secret-key-change-in-production');
+    const user = await User.findById(decoded.userId).select('_id isAdmin moderationStatus');
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    req.user = user;
+    return next();
+  } catch {
+    return res.status(403).json({ error: 'Invalid or expired token' });
+  }
+};
+
+const requireAdmin = (req, res, next) => {
+  if (!req.user?.isAdmin) {
+    return res.status(403).json({ error: 'Admin access required' });
+  }
+  return next();
+};
+
+router.post('/report', [
+  authenticateToken,
+  body('targetType').isIn(['post', 'comment', 'user', 'message']),
+  body('targetId').isMongoId(),
+  body('targetUserId').isMongoId(),
+  body('category').isIn(['spam', 'harassment', 'hate_speech', 'misinformation', 'illegal_content', 'self_harm', 'other']),
+  body('description').optional().isString().isLength({ max: 1000 })
+], async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const since = new Date(Date.now() - REPORT_LIMIT_WINDOW_MS);
+    const recentCount = await Report.countDocuments({
+      reporterId: req.user._id,
+      createdAt: { $gte: since }
+    });
+
+    if (recentCount >= REPORT_LIMIT_MAX) {
+      return res.status(429).json({ error: 'Report rate limit exceeded (5 per hour)' });
+    }
+
+    const report = await Report.create({
+      reporterId: req.user._id,
+      targetType: req.body.targetType,
+      targetId: req.body.targetId,
+      targetUserId: req.body.targetUserId,
+      category: req.body.category,
+      description: req.body.description || ''
+    });
+
+    const reportCountForTarget = await Report.countDocuments({
+      targetType: report.targetType,
+      targetId: report.targetId,
+      status: { $in: ['pending', 'under_review'] }
+    });
+
+    if (report.targetType === 'post' && reportCountForTarget >= 3) {
+      await Post.findByIdAndUpdate(report.targetId, {
+        $set: {
+          visibility: 'private',
+          updatedAt: new Date()
+        }
+      });
+
+      report.isAutoHidden = true;
+      report.priority = 'high';
+      await report.save();
+    }
+
+    return res.status(201).json({ success: true, reportId: report._id, status: report.status, isAutoHidden: report.isAutoHidden });
+  } catch (error) {
+    console.error('Report creation error:', error);
+    return res.status(500).json({ error: 'Failed to submit report' });
+  }
+});
+
+router.get('/my-reports', authenticateToken, async (req, res) => {
+  try {
+    const reports = await Report.find({ reporterId: req.user._id })
+      .sort({ createdAt: -1 })
+      .limit(100)
+      .lean();
+
+    return res.json({
+      reports: reports.map((report) => ({
+        id: report._id,
+        targetType: report.targetType,
+        targetId: report.targetId,
+        category: report.category,
+        status: report.status,
+        resolution: report.resolution,
+        appeal: report.appeal,
+        createdAt: report.createdAt,
+        updatedAt: report.updatedAt
+      }))
+    });
+  } catch (error) {
+    console.error('Get my reports error:', error);
+    return res.status(500).json({ error: 'Failed to load reports' });
+  }
+});
+
+router.get('/account-actions', authenticateToken, async (req, res) => {
+  try {
+    const user = await User.findById(req.user._id).select('moderationStatus moderationHistory').lean();
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    return res.json({
+      moderationStatus: user.moderationStatus || 'active',
+      moderationHistory: Array.isArray(user.moderationHistory) ? user.moderationHistory : []
+    });
+  } catch (error) {
+    console.error('Account actions error:', error);
+    return res.status(500).json({ error: 'Failed to load account moderation actions' });
+  }
+});
+
+router.get('/blocks', authenticateToken, async (req, res) => {
+  try {
+    const blocked = await BlockList.find({ userId: req.user._id })
+      .sort({ createdAt: -1 })
+      .populate('blockedUserId', 'username realName avatarUrl')
+      .lean();
+
+    return res.json({
+      blockedUsers: blocked.map((entry) => ({
+        _id: entry.blockedUserId?._id,
+        username: entry.blockedUserId?.username,
+        realName: entry.blockedUserId?.realName,
+        avatarUrl: entry.blockedUserId?.avatarUrl,
+        blockedAt: entry.createdAt,
+        reason: entry.reason || ''
+      }))
+    });
+  } catch (error) {
+    console.error('Get blocks error:', error);
+    return res.status(500).json({ error: 'Failed to load block list' });
+  }
+});
+
+router.post('/block', [
+  authenticateToken,
+  body('userId').isMongoId(),
+  body('reason').optional().isString().isLength({ max: 200 })
+], async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const blockedUserId = String(req.body.userId);
+    if (String(req.user._id) === blockedUserId) {
+      return res.status(400).json({ error: 'You cannot block yourself' });
+    }
+
+    await BlockList.findOneAndUpdate(
+      { userId: req.user._id, blockedUserId },
+      { $set: { reason: req.body.reason || '', updatedAt: new Date() } },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+
+    return res.status(201).json({ success: true, message: 'User blocked' });
+  } catch (error) {
+    console.error('Block user error:', error);
+    return res.status(500).json({ error: 'Failed to block user' });
+  }
+});
+
+router.delete('/block/:userId', authenticateToken, async (req, res) => {
+  try {
+    await BlockList.findOneAndDelete({ userId: req.user._id, blockedUserId: req.params.userId });
+    return res.json({ success: true, message: 'User unblocked' });
+  } catch (error) {
+    console.error('Unblock user error:', error);
+    return res.status(500).json({ error: 'Failed to unblock user' });
+  }
+});
+
+router.get('/mutes', authenticateToken, async (req, res) => {
+  try {
+    const muted = await MuteList.find({ userId: req.user._id })
+      .sort({ createdAt: -1 })
+      .populate('mutedUserId', 'username realName avatarUrl')
+      .lean();
+
+    return res.json({
+      mutedUsers: muted.map((entry) => ({
+        _id: entry.mutedUserId?._id,
+        username: entry.mutedUserId?.username,
+        realName: entry.mutedUserId?.realName,
+        avatarUrl: entry.mutedUserId?.avatarUrl,
+        mutedAt: entry.createdAt
+      }))
+    });
+  } catch (error) {
+    console.error('Get mutes error:', error);
+    return res.status(500).json({ error: 'Failed to load mute list' });
+  }
+});
+
+router.post('/mute', [
+  authenticateToken,
+  body('userId').isMongoId()
+], async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const mutedUserId = String(req.body.userId);
+    if (String(req.user._id) === mutedUserId) {
+      return res.status(400).json({ error: 'You cannot mute yourself' });
+    }
+
+    await MuteList.findOneAndUpdate(
+      { userId: req.user._id, mutedUserId },
+      { $set: { updatedAt: new Date() } },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+
+    return res.status(201).json({ success: true, message: 'User muted' });
+  } catch (error) {
+    console.error('Mute user error:', error);
+    return res.status(500).json({ error: 'Failed to mute user' });
+  }
+});
+
+router.delete('/mute/:userId', authenticateToken, async (req, res) => {
+  try {
+    await MuteList.findOneAndDelete({ userId: req.user._id, mutedUserId: req.params.userId });
+    return res.json({ success: true, message: 'User unmuted' });
+  } catch (error) {
+    console.error('Unmute user error:', error);
+    return res.status(500).json({ error: 'Failed to unmute user' });
+  }
+});
+
+router.get('/reports', authenticateToken, requireAdmin, async (req, res) => {
+  try {
+    const page = Math.max(parseInt(req.query.page, 10) || 1, 1);
+    const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 20, 1), 100);
+    const query = {};
+
+    if (req.query.status) query.status = req.query.status;
+    if (req.query.category) query.category = req.query.category;
+    if (req.query.priority) query.priority = req.query.priority;
+
+    const [reports, total] = await Promise.all([
+      Report.find(query)
+        .sort({ createdAt: -1 })
+        .skip((page - 1) * limit)
+        .limit(limit)
+        .populate('reporterId', 'username realName')
+        .populate('targetUserId', 'username realName')
+        .lean(),
+      Report.countDocuments(query)
+    ]);
+
+    return res.json({
+      reports,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.max(Math.ceil(total / limit), 1)
+      }
+    });
+  } catch (error) {
+    console.error('Admin reports error:', error);
+    return res.status(500).json({ error: 'Failed to load reports' });
+  }
+});
+
+router.put('/reports/:reportId', [
+  authenticateToken,
+  requireAdmin,
+  body('status').optional().isIn(['pending', 'under_review', 'resolved', 'dismissed']),
+  body('resolution.action').optional().isIn(['none', 'warning', 'content_removed', 'suspension', 'ban']),
+  body('resolution.reason').optional().isString().isLength({ max: 1000 })
+], async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const report = await Report.findById(req.params.reportId);
+    if (!report) {
+      return res.status(404).json({ error: 'Report not found' });
+    }
+
+    if (req.body.status) {
+      report.status = req.body.status;
+    }
+
+    if (req.body.resolution) {
+      report.resolution = {
+        ...report.resolution,
+        ...req.body.resolution,
+        resolvedBy: req.user._id,
+        resolvedAt: new Date()
+      };
+    }
+
+    await report.save();
+    return res.json({ success: true, report });
+  } catch (error) {
+    console.error('Update report error:', error);
+    return res.status(500).json({ error: 'Failed to update report' });
+  }
+});
+
+router.post('/actions', [
+  authenticateToken,
+  requireAdmin,
+  body('targetUserId').isMongoId(),
+  body('action').isIn(['warning', 'suspension', 'ban']),
+  body('reason').optional().isString().isLength({ max: 1000 }),
+  body('duration').optional().isInt({ min: 1, max: 3650 })
+], async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const user = await User.findById(req.body.targetUserId);
+    if (!user) {
+      return res.status(404).json({ error: 'Target user not found' });
+    }
+
+    const action = req.body.action;
+    const duration = req.body.duration ? Number(req.body.duration) : null;
+
+    user.moderationStatus = action === 'warning' ? 'warned' : action === 'suspension' ? 'suspended' : 'banned';
+    user.registrationStatus = action === 'warning' ? 'active' : 'suspended';
+    user.moderationHistory.push({
+      action,
+      reason: req.body.reason || '',
+      duration,
+      appliedBy: req.user._id,
+      expiresAt: duration ? new Date(Date.now() + duration * 24 * 60 * 60 * 1000) : null
+    });
+
+    await user.save();
+    return res.json({ success: true, moderationStatus: user.moderationStatus });
+  } catch (error) {
+    console.error('Moderation action error:', error);
+    return res.status(500).json({ error: 'Failed to apply moderation action' });
+  }
+});
+
+router.post('/appeals', [
+  authenticateToken,
+  body('reportId').isMongoId(),
+  body('justification').isString().trim().isLength({ min: 10, max: 1500 })
+], async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const report = await Report.findById(req.body.reportId);
+    if (!report) {
+      return res.status(404).json({ error: 'Report not found' });
+    }
+
+    if (String(report.targetUserId) !== String(req.user._id) && String(report.reporterId) !== String(req.user._id)) {
+      return res.status(403).json({ error: 'Not authorized to appeal this report' });
+    }
+
+    report.appeal = {
+      status: 'pending',
+      justification: req.body.justification,
+      reviewedBy: null,
+      reviewedAt: null,
+      decision: ''
+    };
+    await report.save();
+
+    return res.status(201).json({ success: true, message: 'Appeal submitted' });
+  } catch (error) {
+    console.error('Submit appeal error:', error);
+    return res.status(500).json({ error: 'Failed to submit appeal' });
+  }
+});
+
+router.get('/appeals', authenticateToken, requireAdmin, async (req, res) => {
+  try {
+    const appeals = await Report.find({ 'appeal.status': 'pending' })
+      .sort({ updatedAt: -1 })
+      .limit(100)
+      .populate('targetUserId', 'username realName')
+      .populate('reporterId', 'username realName')
+      .lean();
+
+    return res.json({ appeals });
+  } catch (error) {
+    console.error('Get appeals error:', error);
+    return res.status(500).json({ error: 'Failed to load appeals' });
+  }
+});
+
+router.put('/appeals/:reportId', [
+  authenticateToken,
+  requireAdmin,
+  body('status').isIn(['approved', 'rejected']),
+  body('decision').optional().isString().isLength({ max: 1000 })
+], async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const report = await Report.findById(req.params.reportId);
+    if (!report) {
+      return res.status(404).json({ error: 'Report not found' });
+    }
+
+    report.appeal.status = req.body.status;
+    report.appeal.decision = req.body.decision || '';
+    report.appeal.reviewedBy = req.user._id;
+    report.appeal.reviewedAt = new Date();
+
+    if (req.body.status === 'approved') {
+      report.status = 'dismissed';
+      report.resolution = {
+        ...report.resolution,
+        action: 'none',
+        reason: 'Appeal approved',
+        resolvedBy: req.user._id,
+        resolvedAt: new Date()
+      };
+    }
+
+    await report.save();
+    return res.json({ success: true, report });
+  } catch (error) {
+    console.error('Process appeal error:', error);
+    return res.status(500).json({ error: 'Failed to process appeal' });
+  }
+});
+
+module.exports = router;

--- a/routes/public.js
+++ b/routes/public.js
@@ -1,8 +1,10 @@
 const express = require('express');
 const mongoose = require('mongoose');
+const jwt = require('jsonwebtoken');
 const router = express.Router();
 const User = require('../models/User');
 const Post = require('../models/Post');
+const BlockList = require('../models/BlockList');
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_LIMIT = 20;
@@ -51,6 +53,29 @@ const toPublicUserProfile = (userDoc) => {
     hasPGP: !!userDoc.pgpPublicKey,
     createdAt: userDoc.createdAt
   };
+};
+
+const getViewerIdFromAuthHeader = (req) => {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) return null;
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'your-secret-key-change-in-production');
+    return decoded.userId ? String(decoded.userId) : null;
+  } catch {
+    return null;
+  }
+};
+
+const hasBlockRelationship = async (viewerId, targetId) => {
+  if (!viewerId || !targetId) return false;
+  const record = await BlockList.findOne({
+    $or: [
+      { userId: viewerId, blockedUserId: targetId },
+      { userId: targetId, blockedUserId: viewerId }
+    ]
+  }).select('_id').lean();
+  return !!record;
 };
 
 const findUserByIdOrUsername = async (identifier) => {
@@ -135,6 +160,12 @@ router.get('/users/:username', async (req, res) => {
       return res.status(404).json({ error: 'User not found' });
     }
 
+    const viewerId = getViewerIdFromAuthHeader(req);
+    const blocked = await hasBlockRelationship(viewerId, user._id);
+    if (blocked) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
     return res.json({
       success: true,
       user: toPublicUserProfile(user)
@@ -150,6 +181,12 @@ router.get('/users/:userId/feed', async (req, res) => {
   try {
     const user = await findUserByIdOrUsername(req.params.userId);
     if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    const viewerId = getViewerIdFromAuthHeader(req);
+    const blocked = await hasBlockRelationship(viewerId, user._id);
+    if (blocked) {
       return res.status(404).json({ error: 'User not found' });
     }
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -3,6 +3,18 @@ const router = express.Router();
 const { body, validationResult } = require('express-validator');
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
+const BlockList = require('../models/BlockList');
+
+const hasBlockRelationship = async (viewerId, targetId) => {
+  const record = await BlockList.findOne({
+    $or: [
+      { userId: viewerId, blockedUserId: targetId },
+      { userId: targetId, blockedUserId: viewerId }
+    ]
+  }).select('_id').lean();
+
+  return !!record;
+};
 
 // Middleware to verify JWT token
 const authenticateToken = (req, res, next) => {
@@ -76,6 +88,11 @@ router.get('/username/:username', authenticateToken, async (req, res) => {
       return res.status(404).json({ error: 'User not found' });
     }
 
+    const blocked = await hasBlockRelationship(req.user.userId, user._id);
+    if (blocked) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
     const publicUser = user.toPublicProfile();
     delete publicUser.hasEncryptionPassword;
     
@@ -98,6 +115,11 @@ router.get('/:userId', authenticateToken, async (req, res) => {
       .select('-passwordHash -encryptionPasswordHash -pgpPublicKey');
     
     if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    const blocked = await hasBlockRelationship(req.user.userId, user._id);
+    if (blocked) {
       return res.status(404).json({ error: 'User not found' });
     }
 

--- a/server.js
+++ b/server.js
@@ -153,6 +153,7 @@ registerRoute('/api/location', () => require('./routes/location'));
 registerRoute('/api/universal', () => require('./routes/universal'));
 registerRoute('/api/friends', () => require('./routes/friends'));
 registerRoute('/api/circles', () => require('./routes/circles'));
+registerRoute('/api/moderation', () => require('./routes/moderation'));
 
 let newsRoutes = null;
 let mapsRoutes = null;


### PR DESCRIPTION
## Summary
Implements Issue #8 moderation capabilities: reporting, block/mute controls, admin moderation queue/actions, appeals flow, and transparency surfaces.

## Backend
- Added models:
  - models/Report.js
  - models/BlockList.js
  - models/MuteList.js
- Added moderation route: outes/moderation.js
  - User endpoints: report, my reports, account actions, block/unblock, mute/unmute
  - Admin endpoints: list/update reports, apply moderation actions, list/process appeals
  - Auto-hide behavior for heavily reported posts (threshold-based)
- Extended models/User.js with moderation fields:
  - moderationStatus, moderationHistory, isAdmin
- Mounted moderation API in server.js
- Enforced block/mute across routes:
  - outes/users.js profile visibility restrictions
  - outes/public.js block-aware public profile/feed access
  - outes/feed.js filter blocked/muted users from timeline/feed + block-aware posting checks
  - outes/chat.js prevent sending messages when block relationships exist in room context

## Frontend
- Added components:
  - rontend/src/components/ReportModal.js
  - rontend/src/components/BlockButton.js
- Added admin page:
  - rontend/src/pages/ModerationDashboard.js
- Updated Social experience (rontend/src/pages/Social.js):
  - Report, block/unblock, mute/unmute controls on posts
  - Moderation transparency panel for user report statuses
- Updated app routing/navigation (rontend/src/App.js):
  - Admin-only moderation dashboard route and nav link
- Updated API client (rontend/src/utils/api.js):
  - full moderationAPI surface

## Validation
- Static diagnostics on all changed files: no errors.
- Runtime tests unavailable in this shell environment (node/npm not installed).

Closes #8