### PR TITLE
feat(notifications): Notification Center (#9)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,7 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link, Navigate } from 'react-router-dom';
 import { Toaster } from 'react-hot-toast';
+import { io } from 'socket.io-client';
 import Home from './pages/Home';
 import Login from './pages/Login';
 import Register from './pages/Register';
@@ -14,7 +15,9 @@ import Maps from './pages/Maps';
 import OnboardingPage from './pages/OnboardingPage';
 import SecurityCenter from './pages/SecurityCenter';
 import ModerationDashboard from './pages/ModerationDashboard';
-import { authAPI } from './utils/api';
+import NotificationCenter from './components/NotificationCenter';
+import NotificationSettings from './pages/NotificationSettings';
+import { authAPI, notificationAPI } from './utils/api';
 
 const ProtectedRoute = ({
   isAuthenticated,
@@ -59,6 +62,9 @@ function App() {
       requirePasswordForSensitive: true
     }
   });
+  const [unreadNotificationCount, setUnreadNotificationCount] = useState(0);
+  const [incomingNotification, setIncomingNotification] = useState(null);
+  const notificationSocketRef = useRef(null);
 
   const isAuthenticated = useMemo(() => Boolean(localStorage.getItem('token') && user), [user]);
   const onboardingRequired = isAuthenticated && onboardingStatus.status !== 'completed';
@@ -148,6 +154,7 @@ function App() {
       try {
         const { data } = await authAPI.getProfile();
         setUser(data.user);
+        setUnreadNotificationCount(Number(data.user?.unreadNotificationCount || 0));
         setOnboardingStatus((prev) => ({
           ...prev,
           status: data.user?.onboardingStatus || 'pending',
@@ -180,9 +187,64 @@ function App() {
     refreshOnboardingStatus();
   }, [isAuthenticated]);
 
+  useEffect(() => {
+    const bootstrapNotifications = async () => {
+      if (!isAuthenticated) {
+        setUnreadNotificationCount(0);
+        return;
+      }
+
+      try {
+        const { data } = await notificationAPI.getUnreadCount();
+        setUnreadNotificationCount(Number(data?.count || 0));
+      } catch {
+        // ignore notification count refresh failures
+      }
+    };
+
+    bootstrapNotifications();
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    if (!isAuthenticated || !user?._id) {
+      if (notificationSocketRef.current) {
+        notificationSocketRef.current.disconnect();
+        notificationSocketRef.current = null;
+      }
+      return;
+    }
+
+    const socketOrigin = process.env.REACT_APP_SOCKET_URL || window.location.origin;
+    const socket = io(socketOrigin, {
+      auth: {
+        userId: String(user._id)
+      }
+    });
+
+    socket.on('connect', () => {
+      socket.emit('join-user', String(user._id));
+    });
+
+    socket.on('notification', (payload) => {
+      if (!payload) return;
+      setIncomingNotification(payload);
+      setUnreadNotificationCount((prev) => prev + (payload.isRead ? 0 : 1));
+    });
+
+    notificationSocketRef.current = socket;
+
+    return () => {
+      socket.disconnect();
+      if (notificationSocketRef.current === socket) {
+        notificationSocketRef.current = null;
+      }
+    };
+  }, [isAuthenticated, user?._id]);
+
   const handleAuthSuccess = (payload) => {
     localStorage.setItem('token', payload.token);
     setUser(payload.user);
+    setUnreadNotificationCount(Number(payload.user?.unreadNotificationCount || 0));
     setOnboardingStatus((prev) => ({
       ...prev,
       status: payload.user?.onboardingStatus || 'pending',
@@ -214,6 +276,8 @@ function App() {
       encryptionPasswordSetAt: null,
       encryptionPasswordVersion: 0
     });
+    setUnreadNotificationCount(0);
+    setIncomingNotification(null);
   };
 
   const handleOnboardingCompleted = async () => {
@@ -247,6 +311,13 @@ function App() {
               {isAuthenticated && !encryptionPasswordRequired && !onboardingRequired && <Link to="/security" className="text-gray-600 hover:text-blue-600">Security</Link>}
               {isAuthenticated && user?.isAdmin && !encryptionPasswordRequired && !onboardingRequired && <Link to="/moderation" className="text-gray-600 hover:text-blue-600">Moderation</Link>}
               {isAuthenticated && !encryptionPasswordRequired && !onboardingRequired && <Link to="/refer" className="text-gray-600 hover:text-blue-600">Refer Friend</Link>}
+              {isAuthenticated && !encryptionPasswordRequired && !onboardingRequired && (
+                <NotificationCenter
+                  unreadCount={unreadNotificationCount}
+                  onUnreadCountChange={setUnreadNotificationCount}
+                  incomingNotification={incomingNotification}
+                />
+              )}
               {isAuthenticated && onboardingRequired && <Link to="/onboarding" className="text-blue-600 font-medium">Onboarding</Link>}
               {isAuthenticated ? (
                 <>
@@ -374,6 +445,18 @@ function App() {
                   encryptionPasswordRequired={encryptionPasswordRequired}
                 >
                   <Social />
+                </ProtectedRoute>
+              )}
+            />
+            <Route
+              path="/notification-settings"
+              element={(
+                <ProtectedRoute
+                  isAuthenticated={isAuthenticated}
+                  onboardingRequired={onboardingRequired}
+                  encryptionPasswordRequired={encryptionPasswordRequired}
+                >
+                  <NotificationSettings />
                 </ProtectedRoute>
               )}
             />

--- a/frontend/src/components/NotificationCenter.js
+++ b/frontend/src/components/NotificationCenter.js
@@ -1,0 +1,189 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { notificationAPI } from '../utils/api';
+import NotificationItem from './NotificationItem';
+
+const PAGE_SIZE = 20;
+
+const NotificationCenter = ({ unreadCount = 0, onUnreadCountChange, incomingNotification }) => {
+  const navigate = useNavigate();
+  const panelRef = useRef(null);
+  const [open, setOpen] = useState(false);
+  const [notifications, setNotifications] = useState([]);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const loadNotifications = async (nextPage = 1, replace = false) => {
+    setLoading(true);
+    try {
+      const response = await notificationAPI.getNotifications(nextPage, PAGE_SIZE);
+      const incoming = Array.isArray(response.data?.notifications)
+        ? response.data.notifications
+        : [];
+
+      setNotifications((prev) => {
+        if (replace || nextPage === 1) return incoming;
+        const map = new Map(prev.map((item) => [String(item._id), item]));
+        for (const item of incoming) {
+          map.set(String(item._id), item);
+        }
+        return [...map.values()].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+      });
+
+      setPage(nextPage);
+      setHasMore(Boolean(response.data?.pagination?.hasMore));
+    } catch {
+      if (replace) {
+        setNotifications([]);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      loadNotifications(1, true);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!incomingNotification) return;
+    setNotifications((prev) => [incomingNotification, ...prev.filter((item) => String(item._id) !== String(incomingNotification._id))]);
+  }, [incomingNotification]);
+
+  useEffect(() => {
+    const handler = (event) => {
+      if (!open) return;
+      if (panelRef.current && !panelRef.current.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const markRead = async (id) => {
+    try {
+      await notificationAPI.markAsRead(id);
+      setNotifications((prev) => prev.map((item) => (
+        String(item._id) === String(id)
+          ? { ...item, isRead: true, readAt: new Date().toISOString() }
+          : item
+      )));
+      onUnreadCountChange((prev) => Math.max(0, prev - 1));
+    } catch {
+      // no-op
+    }
+  };
+
+  const deleteNotification = async (id) => {
+    const target = notifications.find((item) => String(item._id) === String(id));
+    try {
+      await notificationAPI.deleteNotification(id);
+      setNotifications((prev) => prev.filter((item) => String(item._id) !== String(id)));
+      if (target && !target.isRead) {
+        onUnreadCountChange((prev) => Math.max(0, prev - 1));
+      }
+    } catch {
+      // no-op
+    }
+  };
+
+  const openNotification = async (notification) => {
+    if (!notification?.isRead) {
+      await markRead(notification._id);
+    }
+
+    const targetUrl = String(notification?.data?.url || '').trim();
+    if (targetUrl.startsWith('/')) {
+      navigate(targetUrl);
+      setOpen(false);
+      return;
+    }
+
+    if (targetUrl.startsWith('http://') || targetUrl.startsWith('https://')) {
+      window.location.href = targetUrl;
+      return;
+    }
+
+    if (notification?.data?.postId) {
+      navigate(`/social?post=${encodeURIComponent(String(notification.data.postId))}`);
+      setOpen(false);
+      return;
+    }
+
+    if (notification?.data?.roomId) {
+      navigate('/chat');
+      setOpen(false);
+      return;
+    }
+  };
+
+  const markAllRead = async () => {
+    try {
+      await notificationAPI.markAllAsRead();
+      setNotifications((prev) => prev.map((item) => ({ ...item, isRead: true, readAt: item.readAt || new Date().toISOString() })));
+      onUnreadCountChange(0);
+    } catch {
+      // no-op
+    }
+  };
+
+  const handleScroll = (event) => {
+    const el = event.currentTarget;
+    const nearBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 24;
+    if (nearBottom && hasMore && !loading) {
+      loadNotifications(page + 1);
+    }
+  };
+
+  return (
+    <div className="relative" ref={panelRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="relative text-gray-600 hover:text-blue-600"
+        aria-label="Notifications"
+      >
+        🔔
+        {unreadCount > 0 ? (
+          <span className="absolute -top-2 -right-3 min-w-[18px] h-[18px] px-1 rounded-full bg-red-600 text-white text-[10px] leading-[18px] text-center">
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </span>
+        ) : null}
+      </button>
+
+      {open ? (
+        <div className="absolute right-0 mt-2 w-96 max-w-[92vw] bg-white border rounded-lg shadow-lg z-50">
+          <div className="flex items-center justify-between px-3 py-2 border-b">
+            <p className="font-semibold text-gray-900">Notifications</p>
+            <div className="flex items-center gap-3">
+              <button type="button" className="text-xs text-blue-600 hover:text-blue-700" onClick={markAllRead}>Mark all read</button>
+              <Link to="/notification-settings" className="text-xs text-gray-600 hover:text-gray-800" onClick={() => setOpen(false)}>Settings</Link>
+            </div>
+          </div>
+
+          <div className="max-h-96 overflow-y-auto" onScroll={handleScroll}>
+            {notifications.length === 0 && !loading ? (
+              <div className="p-4 text-sm text-gray-500">No notifications yet.</div>
+            ) : notifications.map((notification) => (
+              <NotificationItem
+                key={String(notification._id)}
+                notification={notification}
+                onOpen={openNotification}
+                onMarkRead={markRead}
+                onDelete={deleteNotification}
+              />
+            ))}
+            {loading ? <div className="p-3 text-xs text-gray-500">Loading...</div> : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default NotificationCenter;

--- a/frontend/src/components/NotificationItem.js
+++ b/frontend/src/components/NotificationItem.js
@@ -1,0 +1,62 @@
+import React from 'react';
+
+const formatRelativeTime = (value) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+
+  const diffMs = Date.now() - date.getTime();
+  const diffMinutes = Math.floor(diffMs / (1000 * 60));
+  if (diffMinutes < 1) return 'Just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return date.toLocaleDateString();
+};
+
+const NotificationItem = ({ notification, onOpen, onMarkRead, onDelete }) => {
+  const id = String(notification?._id || '');
+
+  return (
+    <div className={`border-b px-3 py-2 ${notification?.isRead ? 'bg-white' : 'bg-blue-50'}`}>
+      <button
+        type="button"
+        onClick={() => onOpen(notification)}
+        className="w-full text-left"
+      >
+        <div className="flex items-start justify-between gap-2">
+          <p className="font-medium text-sm text-gray-900">{notification?.title || 'Notification'}</p>
+          <span className="text-xs text-gray-500 whitespace-nowrap">{formatRelativeTime(notification?.createdAt)}</span>
+        </div>
+        {notification?.body ? (
+          <p className="text-sm text-gray-700 mt-1">{notification.body}</p>
+        ) : null}
+      </button>
+
+      <div className="mt-2 flex gap-2">
+        {!notification?.isRead ? (
+          <button
+            type="button"
+            onClick={() => onMarkRead(id)}
+            className="text-xs text-blue-600 hover:text-blue-700"
+          >
+            Mark read
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={() => onDelete(id)}
+          className="text-xs text-red-600 hover:text-red-700"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default NotificationItem;

--- a/frontend/src/pages/NotificationSettings.js
+++ b/frontend/src/pages/NotificationSettings.js
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from 'react';
+import { notificationAPI } from '../utils/api';
+
+const CHANNELS = ['inApp', 'email', 'push'];
+
+const TYPE_LABELS = {
+  likes: 'Likes',
+  comments: 'Comments',
+  mentions: 'Mentions',
+  follows: 'Follows',
+  messages: 'Messages',
+  system: 'System announcements',
+  securityAlerts: 'Security alerts'
+};
+
+const defaultPreferences = {
+  likes: { inApp: true, email: false, push: false },
+  comments: { inApp: true, email: true, push: false },
+  mentions: { inApp: true, email: true, push: false },
+  follows: { inApp: true, email: false, push: false },
+  messages: { inApp: true, email: false, push: false },
+  system: { inApp: true, email: true, push: false },
+  securityAlerts: { inApp: true, email: true, push: false }
+};
+
+const NotificationSettings = () => {
+  const [preferences, setPreferences] = useState(defaultPreferences);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  useEffect(() => {
+    const loadPreferences = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const response = await notificationAPI.getPreferences();
+        const incoming = response.data?.preferences;
+        if (incoming && typeof incoming === 'object') {
+          setPreferences({ ...defaultPreferences, ...incoming });
+        }
+      } catch (requestError) {
+        setError(requestError.response?.data?.error || 'Failed to load preferences');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadPreferences();
+  }, []);
+
+  const handleToggle = (type, channel) => {
+    setPreferences((prev) => ({
+      ...prev,
+      [type]: {
+        ...prev[type],
+        [channel]: !prev[type]?.[channel]
+      }
+    }));
+  };
+
+  const save = async () => {
+    setSaving(true);
+    setError('');
+    setSuccess('');
+    try {
+      await notificationAPI.updatePreferences(preferences);
+      setSuccess('Notification preferences updated.');
+    } catch (requestError) {
+      setError(requestError.response?.data?.error || 'Failed to save preferences');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 bg-white shadow rounded-lg">
+      <h1 className="text-2xl font-bold text-gray-900 mb-2">Notification Settings</h1>
+      <p className="text-sm text-gray-600 mb-6">Choose which notifications you receive by channel.</p>
+
+      {error ? <div className="mb-4 p-3 rounded bg-red-50 text-red-700 border border-red-200">{error}</div> : null}
+      {success ? <div className="mb-4 p-3 rounded bg-green-50 text-green-700 border border-green-200">{success}</div> : null}
+
+      {loading ? (
+        <div className="text-gray-500">Loading preferences...</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full border border-gray-200 text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="text-left px-3 py-2 border-b">Type</th>
+                <th className="text-left px-3 py-2 border-b">In-app</th>
+                <th className="text-left px-3 py-2 border-b">Email</th>
+                <th className="text-left px-3 py-2 border-b">Push</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.keys(TYPE_LABELS).map((typeKey) => (
+                <tr key={typeKey}>
+                  <td className="px-3 py-2 border-b font-medium text-gray-800">{TYPE_LABELS[typeKey]}</td>
+                  {CHANNELS.map((channel) => (
+                    <td key={`${typeKey}:${channel}`} className="px-3 py-2 border-b">
+                      <label className="inline-flex items-center gap-2 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={Boolean(preferences[typeKey]?.[channel])}
+                          onChange={() => handleToggle(typeKey, channel)}
+                        />
+                        <span>{channel}</span>
+                      </label>
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="mt-6">
+        <button
+          type="button"
+          onClick={save}
+          disabled={saving || loading}
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-60"
+        >
+          {saving ? 'Saving...' : 'Save Preferences'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default NotificationSettings;

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -255,6 +255,16 @@ export const circlesAPI = {
   removeMember: (circleName, userId) => api.delete(`/circles/${encodeURIComponent(circleName)}/members/${encodeURIComponent(userId)}`),
 };
 
+export const notificationAPI = {
+  getNotifications: (page = 1, limit = 20) => api.get(`/notifications?page=${page}&limit=${limit}`),
+  getUnreadCount: () => api.get('/notifications/unread-count'),
+  markAsRead: (id) => api.put(`/notifications/${encodeURIComponent(id)}/read`),
+  markAllAsRead: () => api.put('/notifications/read-all'),
+  deleteNotification: (id) => api.delete(`/notifications/${encodeURIComponent(id)}`),
+  getPreferences: () => api.get('/notifications/preferences'),
+  updatePreferences: (data) => api.put('/notifications/preferences', data),
+};
+
 // News API
 export const newsAPI = {
   // Get personalized news feed

--- a/models/Notification.js
+++ b/models/Notification.js
@@ -1,0 +1,93 @@
+const mongoose = require('mongoose');
+
+const notificationSchema = new mongoose.Schema({
+  recipientId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true
+  },
+  senderId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    default: null
+  },
+  type: {
+    type: String,
+    enum: ['like', 'comment', 'mention', 'follow', 'message', 'system', 'security_alert'],
+    required: true
+  },
+  title: {
+    type: String,
+    required: true,
+    maxlength: 100,
+    trim: true
+  },
+  body: {
+    type: String,
+    maxlength: 500,
+    trim: true,
+    default: ''
+  },
+  data: {
+    postId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Post',
+      default: null
+    },
+    commentId: {
+      type: mongoose.Schema.Types.ObjectId,
+      default: null
+    },
+    messageId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'ChatMessage',
+      default: null
+    },
+    roomId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'ChatRoom',
+      default: null
+    },
+    url: {
+      type: String,
+      default: ''
+    }
+  },
+  isRead: {
+    type: Boolean,
+    default: false,
+    index: true
+  },
+  readAt: {
+    type: Date,
+    default: null
+  },
+  channels: {
+    inApp: {
+      type: Boolean,
+      default: true
+    },
+    email: {
+      type: Boolean,
+      default: false
+    },
+    push: {
+      type: Boolean,
+      default: false
+    }
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+    index: true
+  }
+}, {
+  timestamps: true
+});
+
+notificationSchema.index({ recipientId: 1, isRead: 1, createdAt: -1 });
+notificationSchema.index({ recipientId: 1, createdAt: -1 });
+notificationSchema.index({ createdAt: 1 }, { expireAfterSeconds: 60 * 60 * 24 * 90 });
+
+module.exports = mongoose.model('Notification', notificationSchema);

--- a/models/User.js
+++ b/models/User.js
@@ -241,6 +241,48 @@ const userSchema = new mongoose.Schema({
     type: Boolean,
     default: false
   },
+  notificationPreferences: {
+    likes: {
+      inApp: { type: Boolean, default: true },
+      email: { type: Boolean, default: false },
+      push: { type: Boolean, default: false }
+    },
+    comments: {
+      inApp: { type: Boolean, default: true },
+      email: { type: Boolean, default: true },
+      push: { type: Boolean, default: false }
+    },
+    mentions: {
+      inApp: { type: Boolean, default: true },
+      email: { type: Boolean, default: true },
+      push: { type: Boolean, default: false }
+    },
+    follows: {
+      inApp: { type: Boolean, default: true },
+      email: { type: Boolean, default: false },
+      push: { type: Boolean, default: false }
+    },
+    messages: {
+      inApp: { type: Boolean, default: true },
+      email: { type: Boolean, default: false },
+      push: { type: Boolean, default: false }
+    },
+    system: {
+      inApp: { type: Boolean, default: true },
+      email: { type: Boolean, default: true },
+      push: { type: Boolean, default: false }
+    },
+    securityAlerts: {
+      inApp: { type: Boolean, default: true },
+      email: { type: Boolean, default: true },
+      push: { type: Boolean, default: false }
+    }
+  },
+  unreadNotificationCount: {
+    type: Number,
+    default: 0,
+    min: 0
+  },
   // Friend count (cached for performance)
   friendCount: {
     type: Number,
@@ -316,6 +358,16 @@ userSchema.methods.toPublicProfile = function() {
     hasEncryptionPassword,
     isAdmin: !!this.isAdmin,
     moderationStatus: this.moderationStatus || 'active',
+    unreadNotificationCount: this.unreadNotificationCount || 0,
+    notificationPreferences: this.notificationPreferences || {
+      likes: { inApp: true, email: false, push: false },
+      comments: { inApp: true, email: true, push: false },
+      mentions: { inApp: true, email: true, push: false },
+      follows: { inApp: true, email: false, push: false },
+      messages: { inApp: true, email: false, push: false },
+      system: { inApp: true, email: true, push: false },
+      securityAlerts: { inApp: true, email: true, push: false }
+    },
     onboardingStatus: this.onboardingStatus || 'pending',
     onboardingStep: this.onboardingStep || 1,
     securityPreferences: this.securityPreferences || {

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -9,6 +9,7 @@ const SecurityEvent = require('../models/SecurityEvent');
 const BlockList = require('../models/BlockList');
 const RoomKeyPackage = require('../models/RoomKeyPackage');
 const User = require('../models/User');
+const { createNotification } = require('../services/notifications');
 
 const getClientIp = (req) => {
   const forwarded = req.headers['x-forwarded-for'];
@@ -192,6 +193,29 @@ const createRoomEventMessage = async ({ roomId, userId, content, messageType = '
 const isRoomMember = (room, userId) => {
   if (!room || !Array.isArray(room.members)) return false;
   return room.members.some((memberId) => String(memberId) === String(userId));
+};
+
+const notifyRoomMembers = async ({ room, senderId, senderLabel, message, messageType = 'message' }) => {
+  if (!room || !Array.isArray(room.members)) return;
+
+  const recipientIds = room.members
+    .map((memberId) => String(memberId))
+    .filter((memberId) => memberId && memberId !== String(senderId));
+
+  for (const recipientId of recipientIds) {
+    await createNotification({
+      recipientId,
+      senderId,
+      type: messageType,
+      title: 'New message',
+      body: `${senderLabel} sent a message in ${room.name || room.city || 'a room'}`,
+      data: {
+        messageId: message?._id,
+        roomId: room._id,
+        url: '/chat'
+      }
+    });
+  }
 };
 
 const validateE2EEEnvelope = (envelope) => {
@@ -547,6 +571,9 @@ router.post('/rooms/:roomId/messages', [
     
     // Populate user info for response
     await message.populate('userId', 'username realName');
+
+    const senderLabel = user.username || user.realName || 'Someone';
+    await notifyRoomMembers({ room, senderId: userId, senderLabel, message });
     
     // Broadcast message via WebSocket (handled in server.js)
     // The WebSocket server will handle real-time broadcasting
@@ -698,6 +725,9 @@ router.post('/rooms/:roomId/messages/e2ee', [
     await room.incrementMessageCount();
     await room.addMember(userId);
     await message.populate('userId', 'username realName');
+
+    const senderLabel = user.username || user.realName || 'Someone';
+    await notifyRoomMembers({ room, senderId: userId, senderLabel, message });
 
     return res.status(201).json({
       success: true,

--- a/routes/feed.js
+++ b/routes/feed.js
@@ -7,6 +7,7 @@ const User = require('../models/User');
 const Friendship = require('../models/Friendship');
 const BlockList = require('../models/BlockList');
 const MuteList = require('../models/MuteList');
+const { createNotification } = require('../services/notifications');
 
 const MEDIA_URL_MAX_ITEMS = 8;
 const MEDIA_URL_MAX_LENGTH = 2048;
@@ -62,6 +63,15 @@ const normalizeObjectIdArray = (value) => {
   return value
     .map((entry) => String(entry || '').trim())
     .filter(Boolean);
+};
+
+const extractMentions = (content = '') => {
+  const matches = String(content || '').match(/@([a-zA-Z0-9_.]{3,30})/g) || [];
+  const usernames = new Set();
+  for (const mention of matches) {
+    usernames.add(mention.slice(1).toLowerCase());
+  }
+  return [...usernames];
 };
 
 const canViewerSeePost = (post, viewerId, friendIds, viewerCoordinates = null) => {
@@ -432,7 +442,23 @@ router.post('/post/:postId/like', authenticateToken, async (req, res) => {
       return res.status(403).json({ error: 'Cannot like this post' });
     }
     
+    const wasAlreadyLiked = post.likes.some((likeId) => String(likeId) === String(userId));
     await post.addLike(userId);
+
+    if (!wasAlreadyLiked && String(post.authorId) !== String(userId)) {
+      const actor = await User.findById(userId).select('username realName').lean();
+      await createNotification({
+        recipientId: post.authorId,
+        senderId: userId,
+        type: 'like',
+        title: 'New like',
+        body: `${actor?.username || actor?.realName || 'Someone'} liked your post`,
+        data: {
+          postId: post._id,
+          url: '/social'
+        }
+      });
+    }
     
     res.json({
       success: true,
@@ -500,6 +526,45 @@ router.post('/post/:postId/comment', [
     
     // Get the newly added comment
     const newComment = post.comments[post.comments.length - 1];
+
+    const actor = await User.findById(userId).select('username realName').lean();
+    if (String(post.authorId) !== String(userId)) {
+      await createNotification({
+        recipientId: post.authorId,
+        senderId: userId,
+        type: 'comment',
+        title: 'New comment',
+        body: `${actor?.username || actor?.realName || 'Someone'} commented on your post`,
+        data: {
+          postId: post._id,
+          commentId: newComment?._id,
+          url: '/social'
+        }
+      });
+    }
+
+    const mentionedUsernames = extractMentions(content);
+    if (mentionedUsernames.length > 0) {
+      const mentionedUsers = await User.find({ username: { $in: mentionedUsernames } })
+        .select('_id username')
+        .lean();
+
+      for (const mentionedUser of mentionedUsers) {
+        if (String(mentionedUser._id) === String(userId)) continue;
+        await createNotification({
+          recipientId: mentionedUser._id,
+          senderId: userId,
+          type: 'mention',
+          title: 'You were mentioned',
+          body: `${actor?.username || actor?.realName || 'Someone'} mentioned you in a comment`,
+          data: {
+            postId: post._id,
+            commentId: newComment?._id,
+            url: '/social'
+          }
+        });
+      }
+    }
     
     res.status(201).json({
       success: true,

--- a/routes/friends.js
+++ b/routes/friends.js
@@ -5,6 +5,7 @@ const mongoose = require('mongoose');
 const User = require('../models/User');
 const Friendship = require('../models/Friendship');
 const TopFriend = require('../models/TopFriend');
+const { createNotification } = require('../services/notifications');
 
 // Middleware to verify JWT token
 const authenticateToken = (req, res, next) => {
@@ -91,6 +92,17 @@ router.post('/request', authenticateToken, async (req, res) => {
         existingFriendship.blockedAt = null;
         existingFriendship.removedAt = null;
         await existingFriendship.save();
+
+        await createNotification({
+          recipientId: userId,
+          senderId: req.user._id,
+          type: 'follow',
+          title: 'New follow request',
+          body: `${req.user.username || req.user.realName || 'Someone'} sent you a follow request`,
+          data: {
+            url: '/social'
+          }
+        });
         
         return res.json({
           success: true,
@@ -109,6 +121,17 @@ router.post('/request', authenticateToken, async (req, res) => {
     });
     
     await friendship.save();
+
+    await createNotification({
+      recipientId: userId,
+      senderId: req.user._id,
+      type: 'follow',
+      title: 'New follow request',
+      body: `${req.user.username || req.user.realName || 'Someone'} sent you a follow request`,
+      data: {
+        url: '/social'
+      }
+    });
     
     res.status(201).json({
       success: true,

--- a/routes/notifications.js
+++ b/routes/notifications.js
@@ -1,0 +1,240 @@
+const express = require('express');
+const router = express.Router();
+const jwt = require('jsonwebtoken');
+const { body, validationResult } = require('express-validator');
+const User = require('../models/User');
+const Session = require('../models/Session');
+const Notification = require('../models/Notification');
+const { getUserNotificationPreferences, toPayload } = require('../services/notifications');
+
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 50;
+
+const hashToken = (token = '') => require('crypto').createHash('sha256').update(token).digest('hex');
+
+const getUserFromBearerToken = async (req, select = '') => {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) {
+    return { error: 'No token provided', status: 401 };
+  }
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'your-secret-key-change-in-production');
+
+    const tokenHash = hashToken(token);
+    const session = await Session.findOne({ userId: decoded.userId, tokenHash, isRevoked: false });
+    if (!session) {
+      return { error: 'Session expired or revoked', status: 401 };
+    }
+
+    session.lastActivity = new Date();
+    await session.save();
+
+    const user = await User.findById(decoded.userId).select(select);
+    if (!user) {
+      return { error: 'User not found', status: 404 };
+    }
+
+    return { user };
+  } catch (error) {
+    return { error: 'Invalid token', status: 401 };
+  }
+};
+
+const authenticateToken = async (req, res, next) => {
+  const auth = await getUserFromBearerToken(req, 'notificationPreferences unreadNotificationCount');
+  if (auth.error) {
+    return res.status(auth.status).json({ error: auth.error });
+  }
+
+  req.user = auth.user;
+  next();
+};
+
+router.get('/', authenticateToken, async (req, res) => {
+  try {
+    const page = Math.max(parseInt(req.query.page, 10) || 1, 1);
+    const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || DEFAULT_PAGE_SIZE, 1), MAX_PAGE_SIZE);
+    const skip = (page - 1) * limit;
+
+    const [notifications, total] = await Promise.all([
+      Notification.find({ recipientId: req.user._id })
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+      Notification.countDocuments({ recipientId: req.user._id })
+    ]);
+
+    const hasMore = skip + notifications.length < total;
+
+    return res.json({
+      notifications,
+      pagination: {
+        page,
+        limit,
+        hasMore,
+        total
+      }
+    });
+  } catch (error) {
+    console.error('Notifications list error:', error);
+    return res.status(500).json({ error: 'Failed to load notifications' });
+  }
+});
+
+router.get('/unread-count', authenticateToken, async (req, res) => {
+  return res.json({ count: req.user.unreadNotificationCount || 0 });
+});
+
+router.put('/:id/read', authenticateToken, async (req, res) => {
+  try {
+    const notification = await Notification.findOne({
+      _id: req.params.id,
+      recipientId: req.user._id
+    });
+
+    if (!notification) {
+      return res.status(404).json({ error: 'Notification not found' });
+    }
+
+    if (!notification.isRead) {
+      notification.isRead = true;
+      notification.readAt = new Date();
+      await notification.save();
+
+      await User.updateOne(
+        { _id: req.user._id },
+        { $inc: { unreadNotificationCount: -1 } }
+      );
+
+      await User.updateOne(
+        { _id: req.user._id, unreadNotificationCount: { $lt: 0 } },
+        { $set: { unreadNotificationCount: 0 } }
+      );
+    }
+
+    return res.json({ success: true, notification: toPayload(notification) });
+  } catch (error) {
+    console.error('Mark notification read error:', error);
+    return res.status(500).json({ error: 'Failed to mark notification as read' });
+  }
+});
+
+router.put('/read-all', authenticateToken, async (req, res) => {
+  try {
+    const now = new Date();
+    const result = await Notification.updateMany(
+      { recipientId: req.user._id, isRead: false },
+      { $set: { isRead: true, readAt: now } }
+    );
+
+    await User.updateOne(
+      { _id: req.user._id },
+      { $set: { unreadNotificationCount: 0 } }
+    );
+
+    return res.json({
+      success: true,
+      updatedCount: result.modifiedCount || 0
+    });
+  } catch (error) {
+    console.error('Mark all notifications read error:', error);
+    return res.status(500).json({ error: 'Failed to mark all as read' });
+  }
+});
+
+router.delete('/:id', authenticateToken, async (req, res) => {
+  try {
+    const notification = await Notification.findOne({
+      _id: req.params.id,
+      recipientId: req.user._id
+    });
+
+    if (!notification) {
+      return res.status(404).json({ error: 'Notification not found' });
+    }
+
+    const wasUnread = !notification.isRead;
+    await notification.deleteOne();
+
+    if (wasUnread) {
+      await User.updateOne(
+        { _id: req.user._id },
+        { $inc: { unreadNotificationCount: -1 } }
+      );
+
+      await User.updateOne(
+        { _id: req.user._id, unreadNotificationCount: { $lt: 0 } },
+        { $set: { unreadNotificationCount: 0 } }
+      );
+    }
+
+    return res.json({ success: true });
+  } catch (error) {
+    console.error('Delete notification error:', error);
+    return res.status(500).json({ error: 'Failed to delete notification' });
+  }
+});
+
+router.get('/preferences', authenticateToken, async (req, res) => {
+  return res.json({
+    preferences: getUserNotificationPreferences(req.user)
+  });
+});
+
+router.put('/preferences', [
+  authenticateToken,
+  body('likes').optional().isObject(),
+  body('comments').optional().isObject(),
+  body('mentions').optional().isObject(),
+  body('follows').optional().isObject(),
+  body('messages').optional().isObject(),
+  body('system').optional().isObject(),
+  body('securityAlerts').optional().isObject()
+], async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const existing = getUserNotificationPreferences(req.user);
+    const input = req.body || {};
+
+    const mergePreference = (key) => {
+      const incoming = input[key];
+      if (!incoming || typeof incoming !== 'object' || Array.isArray(incoming)) {
+        return existing[key];
+      }
+
+      return {
+        inApp: typeof incoming.inApp === 'boolean' ? incoming.inApp : existing[key].inApp,
+        email: typeof incoming.email === 'boolean' ? incoming.email : existing[key].email,
+        push: typeof incoming.push === 'boolean' ? incoming.push : existing[key].push
+      };
+    };
+
+    const updatedPreferences = {
+      likes: mergePreference('likes'),
+      comments: mergePreference('comments'),
+      mentions: mergePreference('mentions'),
+      follows: mergePreference('follows'),
+      messages: mergePreference('messages'),
+      system: mergePreference('system'),
+      securityAlerts: mergePreference('securityAlerts')
+    };
+
+    await User.updateOne(
+      { _id: req.user._id },
+      { $set: { notificationPreferences: updatedPreferences } }
+    );
+
+    return res.json({ success: true, preferences: updatedPreferences });
+  } catch (error) {
+    console.error('Update notification preferences error:', error);
+    return res.status(500).json({ error: 'Failed to update notification preferences' });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -154,6 +154,7 @@ registerRoute('/api/universal', () => require('./routes/universal'));
 registerRoute('/api/friends', () => require('./routes/friends'));
 registerRoute('/api/circles', () => require('./routes/circles'));
 registerRoute('/api/moderation', () => require('./routes/moderation'));
+registerRoute('/api/notifications', () => require('./routes/notifications'));
 
 let newsRoutes = null;
 let mapsRoutes = null;
@@ -245,9 +246,23 @@ const io = require('socket.io')(server, {
   }
 });
 
+const { setNotificationIo } = require('./services/notifications');
+setNotificationIo(io);
+
 // Socket.io connection handling
 io.on('connection', (socket) => {
   console.log('New client connected:', socket.id);
+
+  const authUserId = String(socket?.handshake?.auth?.userId || '').trim();
+  if (authUserId) {
+    socket.join(`user:${authUserId}`);
+  }
+
+  socket.on('join-user', (userId) => {
+    const normalizedUserId = String(userId || '').trim();
+    if (!normalizedUserId) return;
+    socket.join(`user:${normalizedUserId}`);
+  });
   
   socket.on('join-room', (roomId) => {
     socket.join(roomId);

--- a/services/notifications.js
+++ b/services/notifications.js
@@ -1,0 +1,140 @@
+const Notification = require('../models/Notification');
+const User = require('../models/User');
+
+let ioInstance = null;
+
+const preferenceMap = {
+  like: 'likes',
+  comment: 'comments',
+  mention: 'mentions',
+  follow: 'follows',
+  message: 'messages',
+  system: 'system',
+  security_alert: 'securityAlerts'
+};
+
+const clampText = (value, max) => String(value || '').trim().slice(0, max);
+
+const toPayload = (notification) => ({
+  _id: notification._id,
+  recipientId: notification.recipientId,
+  senderId: notification.senderId,
+  type: notification.type,
+  title: notification.title,
+  body: notification.body,
+  data: notification.data || {},
+  channels: notification.channels,
+  isRead: notification.isRead,
+  readAt: notification.readAt,
+  createdAt: notification.createdAt
+});
+
+const getUserNotificationPreferences = (user) => {
+  const defaults = {
+    likes: { inApp: true, email: false, push: false },
+    comments: { inApp: true, email: true, push: false },
+    mentions: { inApp: true, email: true, push: false },
+    follows: { inApp: true, email: false, push: false },
+    messages: { inApp: true, email: false, push: false },
+    system: { inApp: true, email: true, push: false },
+    securityAlerts: { inApp: true, email: true, push: false }
+  };
+
+  const candidate = user?.notificationPreferences;
+  if (!candidate || typeof candidate !== 'object') {
+    return defaults;
+  }
+
+  const normalized = { ...defaults };
+  for (const key of Object.keys(defaults)) {
+    if (!candidate[key] || typeof candidate[key] !== 'object') continue;
+    normalized[key] = {
+      inApp: typeof candidate[key].inApp === 'boolean' ? candidate[key].inApp : defaults[key].inApp,
+      email: typeof candidate[key].email === 'boolean' ? candidate[key].email : defaults[key].email,
+      push: typeof candidate[key].push === 'boolean' ? candidate[key].push : defaults[key].push
+    };
+  }
+
+  return normalized;
+};
+
+const setNotificationIo = (io) => {
+  ioInstance = io;
+};
+
+const emitRealtime = (recipientId, payload) => {
+  if (!ioInstance) return;
+  ioInstance.to(`user:${String(recipientId)}`).emit('notification', payload);
+};
+
+const createNotification = async ({
+  recipientId,
+  senderId = null,
+  type,
+  title,
+  body = '',
+  data = {},
+  forceChannels = null
+}) => {
+  if (!recipientId || !type || !title) {
+    return null;
+  }
+
+  if (senderId && String(senderId) === String(recipientId)) {
+    return null;
+  }
+
+  const recipient = await User.findById(recipientId)
+    .select('notificationPreferences unreadNotificationCount registrationStatus')
+    .lean();
+
+  if (!recipient || recipient.registrationStatus !== 'active') {
+    return null;
+  }
+
+  const preferences = getUserNotificationPreferences(recipient);
+  const preferenceKey = preferenceMap[type] || 'system';
+  const prefChannels = preferences[preferenceKey] || { inApp: true, email: false, push: false };
+
+  const channels = forceChannels || {
+    inApp: !!prefChannels.inApp,
+    email: !!prefChannels.email,
+    push: !!prefChannels.push
+  };
+
+  const notification = await Notification.create({
+    recipientId,
+    senderId,
+    type,
+    title: clampText(title, 100),
+    body: clampText(body, 500),
+    data: {
+      postId: data.postId || null,
+      commentId: data.commentId || null,
+      messageId: data.messageId || null,
+      roomId: data.roomId || null,
+      url: clampText(data.url, 500)
+    },
+    channels,
+    isRead: channels.inApp ? false : true,
+    readAt: channels.inApp ? null : new Date()
+  });
+
+  if (channels.inApp) {
+    await User.updateOne(
+      { _id: recipientId },
+      { $inc: { unreadNotificationCount: 1 } }
+    );
+
+    emitRealtime(recipientId, toPayload(notification));
+  }
+
+  return notification;
+};
+
+module.exports = {
+  setNotificationIo,
+  createNotification,
+  getUserNotificationPreferences,
+  toPayload
+};


### PR DESCRIPTION
## Summary
Implements Issue #9 Notification Center with real-time in-app delivery, persistent storage, user preferences, read controls, deep linking, and paginated loading.

## Backend
- Added models/Notification.js with indexed notification storage + 90-day TTL
- Added services/notifications.js for:
  - preference-aware channel resolution (in-app/email/push)
  - unread counter updates
  - real-time Socket.io delivery to user:{id} rooms
- Added outes/notifications.js:
  - GET /notifications (paginated)
  - GET /notifications/unread-count
  - PUT /notifications/:id/read
  - PUT /notifications/read-all
  - DELETE /notifications/:id
  - GET/PUT /notifications/preferences
- Updated models/User.js:
  - 
otificationPreferences
  - unreadNotificationCount
  - exposed fields via 	oPublicProfile()
- Updated server.js:
  - mounted /api/notifications
  - set notification socket service with io
  - added user room joins via handshake auth and join-user
- Added notification triggers:
  - outes/feed.js: like/comment/mention notifications
  - outes/friends.js: follow-request notifications
  - outes/chat.js: message notifications to room members (excluding sender)

## Frontend
- Added rontend/src/components/NotificationCenter.js:
  - bell icon + unread badge
  - dropdown panel
  - infinite-scroll pagination on panel scroll
  - mark read / delete / mark all read
  - deep-link navigation for notification targets
- Added rontend/src/components/NotificationItem.js
- Added rontend/src/pages/NotificationSettings.js for per-type channel toggles
- Updated rontend/src/utils/api.js with 
otificationAPI
- Updated rontend/src/App.js:
  - Socket.io client listener for 
otification
  - unread count bootstrap
  - navbar notification center integration
  - protected route for /notification-settings

## Validation
- VS Code diagnostics: no errors in all changed files.
- Runtime command execution unavailable in this shell (
ode not installed), so runtime tests could not be executed here.

Closes #9