### PR TITLE
feat(discovery): Social Discovery Improvements (#10)

### DIFF
--- a/DISCOVERY.md
+++ b/DISCOVERY.md
@@ -1,0 +1,41 @@
+# Discovery Feature Notes
+
+## Endpoints
+
+- `GET /api/discovery/users`
+- `GET /api/discovery/posts`
+- `POST /api/discovery/events`
+
+## Ranking Signals
+
+### User discovery weights
+
+- `textMatch`: `0.40`
+- `socialSignal` (`friendCount` log-scaled): `0.25`
+- `locationSignal` (`city/state/country` affinity): `0.20`
+- `freshness` (account recency): `0.15`
+- `alreadyFriend` bonus: `+0.05`
+
+### Post discovery weights
+
+- `engagement` (`likes + 2 * comments`, capped): `0.35`
+- `freshness` (post recency): `0.30`
+- `socialSignal` (friend author boost): `0.20`
+- `textMatch` (query relevance): `0.15`
+
+## Tuning Knobs
+
+- Cache TTL: `30s`
+- Rate limit: `60 discovery requests / minute / IP`
+- Max page size: `25`
+- Candidate pool cap before ranking: `300`
+
+## Analytics Events
+
+- Server-emitted impressions:
+  - `discovery_user_impression`
+  - `discovery_post_impression`
+- Client action events (`POST /api/discovery/events`):
+  - `profile_click`
+  - `post_click`
+  - `follow_click`

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,6 +8,7 @@ import Register from './pages/Register';
 import UserSettings from './pages/UserSettings';
 import ReferFriend from './pages/ReferFriend';
 import Social from './pages/Social';
+import Discover from './pages/Discover';
 import Chat from './pages/Chat';
 import Market from './pages/Market';
 import News from './pages/News';
@@ -304,6 +305,7 @@ function App() {
             <div className="space-x-4">
               {!encryptionPasswordRequired && <Link to="/" className="text-gray-600 hover:text-blue-600">Home</Link>}
               {isAuthenticated && !encryptionPasswordRequired && !onboardingRequired && <Link to="/social" className="text-gray-600 hover:text-blue-600">Social</Link>}
+              {isAuthenticated && !encryptionPasswordRequired && !onboardingRequired && <Link to="/discover" className="text-gray-600 hover:text-blue-600">Discover</Link>}
               {isAuthenticated && !encryptionPasswordRequired && !onboardingRequired && <Link to="/chat" className="text-gray-600 hover:text-blue-600">Chat</Link>}
               {isAuthenticated && !encryptionPasswordRequired && !onboardingRequired && <Link to="/market" className="text-gray-600 hover:text-blue-600">Market</Link>}
               {isAuthenticated && !encryptionPasswordRequired && !onboardingRequired && <Link to="/news" className="text-gray-600 hover:text-blue-600">News</Link>}
@@ -433,6 +435,18 @@ function App() {
                   allowWhenEncryptionRequired={false}
                 >
                   {user?.isAdmin ? <ModerationDashboard /> : <Navigate to="/social" replace />}
+                </ProtectedRoute>
+              )}
+            />
+            <Route
+              path="/discover"
+              element={(
+                <ProtectedRoute
+                  isAuthenticated={isAuthenticated}
+                  onboardingRequired={onboardingRequired}
+                  encryptionPasswordRequired={encryptionPasswordRequired}
+                >
+                  <Discover />
                 </ProtectedRoute>
               )}
             />

--- a/frontend/src/pages/Discover.js
+++ b/frontend/src/pages/Discover.js
@@ -1,0 +1,220 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { discoveryAPI } from '../utils/api';
+
+const PAGE_SIZE = 10;
+
+const toWhySuggested = (signals = {}) => {
+  return Object.entries(signals)
+    .filter(([, value]) => (typeof value === 'number' ? value > 0.4 : !!value))
+    .sort((a, b) => {
+      const left = typeof a[1] === 'number' ? a[1] : Number(a[1]);
+      const right = typeof b[1] === 'number' ? b[1] : Number(b[1]);
+      return right - left;
+    })
+    .slice(0, 3)
+    .map(([key]) => key);
+};
+
+function Discover() {
+  const [query, setQuery] = useState('');
+  const [committedQuery, setCommittedQuery] = useState('');
+  const [usersPage, setUsersPage] = useState(1);
+  const [postsPage, setPostsPage] = useState(1);
+  const [users, setUsers] = useState([]);
+  const [posts, setPosts] = useState([]);
+  const [usersTotal, setUsersTotal] = useState(0);
+  const [postsTotal, setPostsTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const totalUserPages = useMemo(() => Math.max(1, Math.ceil(usersTotal / PAGE_SIZE)), [usersTotal]);
+  const totalPostPages = useMemo(() => Math.max(1, Math.ceil(postsTotal / PAGE_SIZE)), [postsTotal]);
+
+  const loadDiscovery = useCallback(async (targetQuery, nextUsersPage, nextPostsPage) => {
+    setLoading(true);
+    setError('');
+
+    try {
+      const [usersResponse, postsResponse] = await Promise.all([
+        discoveryAPI.getUsers(targetQuery, nextUsersPage, PAGE_SIZE),
+        discoveryAPI.getPosts(targetQuery, nextPostsPage, PAGE_SIZE)
+      ]);
+
+      setUsers(Array.isArray(usersResponse.data?.users) ? usersResponse.data.users : []);
+      setPosts(Array.isArray(postsResponse.data?.posts) ? postsResponse.data.posts : []);
+      setUsersTotal(Number(usersResponse.data?.total || 0));
+      setPostsTotal(Number(postsResponse.data?.total || 0));
+    } catch (requestError) {
+      setUsers([]);
+      setPosts([]);
+      setUsersTotal(0);
+      setPostsTotal(0);
+      setError(requestError.response?.data?.error || 'Failed to load discovery results.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadDiscovery(committedQuery, usersPage, postsPage);
+  }, [committedQuery, usersPage, postsPage, loadDiscovery]);
+
+  const submitSearch = (event) => {
+    event.preventDefault();
+    setUsersPage(1);
+    setPostsPage(1);
+    setCommittedQuery(query.trim());
+  };
+
+  const trackProfileClick = async (userId) => {
+    try {
+      await discoveryAPI.trackEvent('profile_click', { targetUserId: userId, query: committedQuery });
+    } catch {
+      // best effort only
+    }
+  };
+
+  const trackPostClick = async (postId) => {
+    try {
+      await discoveryAPI.trackEvent('post_click', { targetPostId: postId, query: committedQuery });
+    } catch {
+      // best effort only
+    }
+  };
+
+  return (
+    <div className="max-w-6xl mx-auto p-4 space-y-6">
+      <div className="bg-white border rounded-lg p-4 shadow-sm">
+        <h2 className="text-2xl font-semibold text-gray-900">Discover people and posts</h2>
+        <p className="text-sm text-gray-600 mt-1">Search and explore ranked suggestions based on relevance, activity, and social context.</p>
+        <form onSubmit={submitSearch} className="mt-4 flex gap-2">
+          <input
+            type="text"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search by username, name, or content"
+            className="flex-1 border rounded px-3 py-2"
+          />
+          <button
+            type="submit"
+            disabled={loading}
+            className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-60"
+          >
+            {loading ? 'Searching...' : 'Search'}
+          </button>
+        </form>
+        {error ? <p className="text-sm text-red-600 mt-3">{error}</p> : null}
+      </div>
+
+      <section className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="bg-white border rounded-lg p-4 shadow-sm">
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-lg font-semibold text-gray-900">People</h3>
+            <span className="text-xs text-gray-500">{usersTotal} total</span>
+          </div>
+
+          <div className="space-y-3">
+            {users.map((user) => {
+              const whySuggested = toWhySuggested(user.ranking?.signals);
+              return (
+                <a
+                  key={String(user._id)}
+                  href={`/social?user=${encodeURIComponent(user.username)}`}
+                  onClick={() => trackProfileClick(String(user._id))}
+                  className="block border rounded p-3 hover:bg-gray-50"
+                >
+                  <div className="font-medium text-gray-900">@{user.username}</div>
+                  <div className="text-sm text-gray-600">{user.realName || 'Unknown'}</div>
+                  <div className="text-xs text-gray-500 mt-1">
+                    {user.city || 'N/A'}{user.state ? `, ${user.state}` : ''}{user.country ? `, ${user.country}` : ''}
+                  </div>
+                  <div className="text-xs text-blue-700 mt-2">
+                    Why suggested: {whySuggested.length ? whySuggested.join(', ') : 'general relevance'}
+                  </div>
+                </a>
+              );
+            })}
+
+            {!loading && users.length === 0 ? (
+              <p className="text-sm text-gray-500">No user suggestions found for this query.</p>
+            ) : null}
+          </div>
+
+          <div className="mt-4 flex justify-between">
+            <button
+              type="button"
+              disabled={usersPage <= 1 || loading}
+              onClick={() => setUsersPage((page) => Math.max(1, page - 1))}
+              className="px-3 py-1 border rounded disabled:opacity-50"
+            >
+              Prev
+            </button>
+            <span className="text-sm text-gray-600">Page {usersPage} / {totalUserPages}</span>
+            <button
+              type="button"
+              disabled={usersPage >= totalUserPages || loading}
+              onClick={() => setUsersPage((page) => page + 1)}
+              className="px-3 py-1 border rounded disabled:opacity-50"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+
+        <div className="bg-white border rounded-lg p-4 shadow-sm">
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-lg font-semibold text-gray-900">Posts</h3>
+            <span className="text-xs text-gray-500">{postsTotal} total</span>
+          </div>
+
+          <div className="space-y-3">
+            {posts.map((post) => {
+              const whySuggested = toWhySuggested(post.ranking?.signals);
+              return (
+                <a
+                  key={String(post._id)}
+                  href="/social"
+                  onClick={() => trackPostClick(String(post._id))}
+                  className="block border rounded p-3 hover:bg-gray-50"
+                >
+                  <div className="text-sm text-gray-900 whitespace-pre-wrap">{post.content || '(No text content)'}</div>
+                  <div className="text-xs text-gray-500 mt-2">By @{post.authorId?.username || 'unknown'} • {new Date(post.createdAt).toLocaleString()}</div>
+                  <div className="text-xs text-gray-500">{post.likesCount || 0} likes • {post.commentsCount || 0} comments</div>
+                  <div className="text-xs text-blue-700 mt-2">
+                    Why suggested: {whySuggested.length ? whySuggested.join(', ') : 'general relevance'}
+                  </div>
+                </a>
+              );
+            })}
+
+            {!loading && posts.length === 0 ? (
+              <p className="text-sm text-gray-500">No post suggestions found for this query.</p>
+            ) : null}
+          </div>
+
+          <div className="mt-4 flex justify-between">
+            <button
+              type="button"
+              disabled={postsPage <= 1 || loading}
+              onClick={() => setPostsPage((page) => Math.max(1, page - 1))}
+              className="px-3 py-1 border rounded disabled:opacity-50"
+            >
+              Prev
+            </button>
+            <span className="text-sm text-gray-600">Page {postsPage} / {totalPostPages}</span>
+            <button
+              type="button"
+              disabled={postsPage >= totalPostPages || loading}
+              onClick={() => setPostsPage((page) => page + 1)}
+              className="px-3 py-1 border rounded disabled:opacity-50"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default Discover;

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -265,6 +265,20 @@ export const notificationAPI = {
   updatePreferences: (data) => api.put('/notifications/preferences', data),
 };
 
+export const discoveryAPI = {
+  getUsers: (q = '', page = 1, limit = 10) => {
+    const params = new URLSearchParams({ page: String(page), limit: String(limit) });
+    if (q) params.append('q', q);
+    return api.get(`/discovery/users?${params.toString()}`);
+  },
+  getPosts: (q = '', page = 1, limit = 10) => {
+    const params = new URLSearchParams({ page: String(page), limit: String(limit) });
+    if (q) params.append('q', q);
+    return api.get(`/discovery/posts?${params.toString()}`);
+  },
+  trackEvent: (eventType, metadata = {}) => api.post('/discovery/events', { eventType, metadata }),
+};
+
 // News API
 export const newsAPI = {
   // Get personalized news feed

--- a/models/Post.js
+++ b/models/Post.js
@@ -139,6 +139,8 @@ postSchema.index({ authorId: 1, createdAt: -1 });
 postSchema.index({ visibility: 1, createdAt: -1 });
 postSchema.index({ authorId: 1, visibility: 1, createdAt: -1 });
 postSchema.index({ expiresAt: 1 });
+postSchema.index({ content: 'text' });
+postSchema.index({ createdAt: -1, visibility: 1, authorId: 1 });
 
 // Method to check if user can view post
 postSchema.methods.canView = function(viewerId, context = {}) {

--- a/models/User.js
+++ b/models/User.js
@@ -302,6 +302,9 @@ const userSchema = new mongoose.Schema({
 
 // Create geospatial index for location-based queries
 userSchema.index({ location: '2dsphere' });
+userSchema.index({ registrationStatus: 1, createdAt: -1 });
+userSchema.index({ city: 1, state: 1, country: 1 });
+userSchema.index({ friendCount: -1, createdAt: -1 });
 
 // Hash password before saving
 userSchema.pre('save', async function(next) {

--- a/routes/discovery.js
+++ b/routes/discovery.js
@@ -1,0 +1,383 @@
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const rateLimit = require('express-rate-limit');
+const User = require('../models/User');
+const Post = require('../models/Post');
+const Friendship = require('../models/Friendship');
+const BlockList = require('../models/BlockList');
+
+const router = express.Router();
+
+const CACHE_TTL_MS = 30 * 1000;
+const DISCOVERY_MAX_LIMIT = 25;
+const discoveryCache = new Map();
+
+const parsePagination = (query) => {
+  const page = Math.max(1, Number.parseInt(query.page, 10) || 1);
+  const limit = Math.min(DISCOVERY_MAX_LIMIT, Math.max(1, Number.parseInt(query.limit, 10) || 10));
+  return { page, limit };
+};
+
+const parseViewerCoordinates = (query) => {
+  const latitude = Number.parseFloat(query.latitude);
+  const longitude = Number.parseFloat(query.longitude);
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    return null;
+  }
+  if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+    return null;
+  }
+  return [longitude, latitude];
+};
+
+const getCache = (cacheKey) => {
+  const entry = discoveryCache.get(cacheKey);
+  if (!entry) return null;
+  if (Date.now() - entry.createdAt > CACHE_TTL_MS) {
+    discoveryCache.delete(cacheKey);
+    return null;
+  }
+  return entry.value;
+};
+
+const setCache = (cacheKey, value) => {
+  discoveryCache.set(cacheKey, {
+    createdAt: Date.now(),
+    value
+  });
+};
+
+const getFriendIds = async (userId) => {
+  const friendships = await Friendship.find({
+    status: 'accepted',
+    $or: [{ requester: userId }, { recipient: userId }]
+  }).select('requester recipient').lean();
+
+  const ids = new Set();
+  for (const friendship of friendships) {
+    const requester = String(friendship.requester);
+    const recipient = String(friendship.recipient);
+    ids.add(requester === String(userId) ? recipient : requester);
+  }
+
+  return ids;
+};
+
+const getBlockedOrMutedIds = async (viewerId) => {
+  const [blocks, blockedByOthers] = await Promise.all([
+    BlockList.find({ userId: viewerId }).select('blockedUserId').lean(),
+    BlockList.find({ blockedUserId: viewerId }).select('userId').lean()
+  ]);
+
+  const blockedOrMuted = new Set();
+  for (const row of blocks) blockedOrMuted.add(String(row.blockedUserId));
+  for (const row of blockedByOthers) blockedOrMuted.add(String(row.userId));
+  return blockedOrMuted;
+};
+
+const scoreTextMatch = (needle, username = '', realName = '') => {
+  const q = String(needle || '').trim().toLowerCase();
+  if (!q) return 0.2;
+
+  const normalizedUsername = String(username || '').toLowerCase();
+  const normalizedRealName = String(realName || '').toLowerCase();
+
+  if (normalizedUsername === q) return 1;
+  if (normalizedUsername.startsWith(q)) return 0.85;
+  if (normalizedRealName.startsWith(q)) return 0.75;
+  if (normalizedUsername.includes(q) || normalizedRealName.includes(q)) return 0.55;
+  return 0;
+};
+
+const scoreLocationAffinity = (viewer, candidate) => {
+  if (!viewer || !candidate) return 0;
+  let score = 0;
+  if (viewer.country && candidate.country && viewer.country === candidate.country) score += 0.3;
+  if (viewer.state && candidate.state && viewer.state === candidate.state) score += 0.35;
+  if (viewer.city && candidate.city && viewer.city === candidate.city) score += 0.35;
+  return Math.min(1, score);
+};
+
+const recencyScore = (dateValue, maxDays = 90) => {
+  const timestamp = new Date(dateValue || 0).getTime();
+  if (!timestamp) return 0;
+  const ageDays = (Date.now() - timestamp) / (1000 * 60 * 60 * 24);
+  return Math.max(0, 1 - (ageDays / maxDays));
+};
+
+const logDiscoveryEvent = ({ userId, eventType, metadata = {}, req }) => {
+  const payload = {
+    eventType,
+    userId,
+    metadata,
+    ipAddress: req.ip,
+    userAgent: req.get('user-agent') || null,
+    createdAt: new Date().toISOString()
+  };
+  console.log('[discovery-event]', JSON.stringify(payload));
+};
+
+const authenticateToken = (req, res, next) => {
+  const authHeader = req.headers.authorization;
+  const token = authHeader && authHeader.split(' ')[1];
+
+  if (!token) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  jwt.verify(token, process.env.JWT_SECRET || 'your-secret-key-change-in-production', async (err, decoded) => {
+    if (err) {
+      return res.status(403).json({ error: 'Invalid or expired token' });
+    }
+
+    try {
+      const user = await User.findById(decoded.userId).select('onboardingStatus city state country');
+      if (!user) {
+        return res.status(401).json({ error: 'User not found' });
+      }
+      if (user.onboardingStatus !== 'completed') {
+        return res.status(403).json({ error: 'Complete onboarding before using discovery', code: 'ONBOARDING_REQUIRED' });
+      }
+
+      req.user = { userId: String(user._id) };
+      req.viewerProfile = {
+        city: user.city || '',
+        state: user.state || '',
+        country: user.country || ''
+      };
+      next();
+    } catch (lookupError) {
+      res.status(500).json({ error: 'Authentication failed' });
+    }
+  });
+};
+
+const discoveryLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many discovery requests, please try again shortly.' }
+});
+
+router.get('/users', authenticateToken, discoveryLimiter, async (req, res) => {
+  try {
+    const viewerId = String(req.user.userId);
+    const query = String(req.query.q || '').trim();
+    const { page, limit } = parsePagination(req.query);
+    const cacheKey = `users:${viewerId}:${query}:${page}:${limit}`;
+
+    const cached = getCache(cacheKey);
+    if (cached) {
+      return res.json({ ...cached, cached: true });
+    }
+
+    const [friendIds, blockedOrMuted] = await Promise.all([
+      getFriendIds(viewerId),
+      getBlockedOrMutedIds(viewerId)
+    ]);
+
+    const searchFilter = {
+      registrationStatus: 'active',
+      _id: { $ne: viewerId }
+    };
+    if (query.length >= 2) {
+      const searchRegex = new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+      searchFilter.$or = [{ username: searchRegex }, { realName: searchRegex }];
+    }
+
+    const candidates = await User.find(searchFilter)
+      .select('_id username realName city state country friendCount createdAt')
+      .sort({ createdAt: -1 })
+      .limit(Math.min(300, Math.max(120, limit * 12)))
+      .lean();
+
+    const ranked = candidates
+      .filter((candidate) => !blockedOrMuted.has(String(candidate._id)))
+      .map((candidate) => {
+        const textMatch = scoreTextMatch(query, candidate.username, candidate.realName);
+        const socialSignal = Math.min(1, Math.log1p(Number(candidate.friendCount || 0)) / 4);
+        const locationSignal = scoreLocationAffinity(req.viewerProfile, candidate);
+        const freshness = recencyScore(candidate.createdAt, 120);
+        const isAlreadyFriend = friendIds.has(String(candidate._id));
+
+        const score =
+          (textMatch * 0.4)
+          + (socialSignal * 0.25)
+          + (locationSignal * 0.2)
+          + (freshness * 0.15)
+          + (isAlreadyFriend ? 0.05 : 0);
+
+        return {
+          ...candidate,
+          ranking: {
+            score: Number(score.toFixed(4)),
+            signals: {
+              textMatch: Number(textMatch.toFixed(3)),
+              socialSignal: Number(socialSignal.toFixed(3)),
+              locationSignal: Number(locationSignal.toFixed(3)),
+              freshness: Number(freshness.toFixed(3)),
+              alreadyFriend: isAlreadyFriend
+            }
+          }
+        };
+      })
+      .sort((a, b) => (b.ranking.score - a.ranking.score) || (new Date(b.createdAt) - new Date(a.createdAt)));
+
+    const total = ranked.length;
+    const start = (page - 1) * limit;
+    const users = ranked.slice(start, start + limit);
+    const responsePayload = {
+      success: true,
+      users,
+      page,
+      limit,
+      total,
+      hasMore: start + limit < total,
+      rankingSignals: ['textMatch', 'socialSignal', 'locationSignal', 'freshness', 'alreadyFriend'],
+      cached: false
+    };
+
+    setCache(cacheKey, responsePayload);
+    logDiscoveryEvent({
+      userId: viewerId,
+      eventType: 'discovery_user_impression',
+      metadata: { query, page, limit, count: users.length },
+      req
+    });
+
+    return res.json(responsePayload);
+  } catch (error) {
+    console.error('User discovery error:', error);
+    return res.status(500).json({ error: 'Failed to load user discovery results', details: error.message });
+  }
+});
+
+router.get('/posts', authenticateToken, discoveryLimiter, async (req, res) => {
+  try {
+    const viewerId = String(req.user.userId);
+    const query = String(req.query.q || '').trim();
+    const { page, limit } = parsePagination(req.query);
+    const viewerCoordinates = parseViewerCoordinates(req.query);
+    const cacheKey = `posts:${viewerId}:${query}:${page}:${limit}:${viewerCoordinates ? viewerCoordinates.join(',') : 'none'}`;
+
+    const cached = getCache(cacheKey);
+    if (cached) {
+      return res.json({ ...cached, cached: true });
+    }
+
+    const [friendIds, blockedOrMuted] = await Promise.all([
+      getFriendIds(viewerId),
+      getBlockedOrMutedIds(viewerId)
+    ]);
+
+    const postFilter = {
+      $or: [
+        { expiresAt: null },
+        { expiresAt: { $gt: new Date() } }
+      ]
+    };
+
+    if (query.length >= 2) {
+      const searchRegex = new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+      postFilter.content = searchRegex;
+    }
+
+    const candidates = await Post.find(postFilter)
+      .sort({ createdAt: -1 })
+      .limit(Math.min(300, Math.max(120, limit * 12)))
+      .populate('authorId', 'username realName city state country')
+      .populate('targetFeedId', 'username realName');
+
+    const ranked = candidates
+      .filter((post) => !blockedOrMuted.has(String(post.authorId?._id || post.authorId)))
+      .filter((post) => post.canView(viewerId, {
+        isFriend: friendIds.has(String(post.authorId?._id || post.authorId)),
+        viewerCoordinates
+      }))
+      .map((post) => {
+        const likesCount = Array.isArray(post.likes) ? post.likes.length : 0;
+        const commentsCount = Array.isArray(post.comments) ? post.comments.length : 0;
+        const engagement = Math.min(1, (likesCount + (commentsCount * 2)) / 25);
+        const freshness = recencyScore(post.createdAt, 30);
+        const socialSignal = friendIds.has(String(post.authorId?._id || post.authorId)) ? 1 : 0.2;
+        const textMatch = scoreTextMatch(query, post.authorId?.username || '', post.content || '');
+        const score = (engagement * 0.35) + (freshness * 0.3) + (socialSignal * 0.2) + (textMatch * 0.15);
+
+        return {
+          _id: post._id,
+          content: post.content,
+          visibility: post.visibility,
+          authorId: post.authorId,
+          targetFeedId: post.targetFeedId,
+          createdAt: post.createdAt,
+          likesCount,
+          commentsCount,
+          ranking: {
+            score: Number(score.toFixed(4)),
+            signals: {
+              engagement: Number(engagement.toFixed(3)),
+              freshness: Number(freshness.toFixed(3)),
+              socialSignal: Number(socialSignal.toFixed(3)),
+              textMatch: Number(textMatch.toFixed(3))
+            }
+          }
+        };
+      })
+      .sort((a, b) => (b.ranking.score - a.ranking.score) || (new Date(b.createdAt) - new Date(a.createdAt)));
+
+    const total = ranked.length;
+    const start = (page - 1) * limit;
+    const posts = ranked.slice(start, start + limit);
+    const responsePayload = {
+      success: true,
+      posts,
+      page,
+      limit,
+      total,
+      hasMore: start + limit < total,
+      rankingSignals: ['engagement', 'freshness', 'socialSignal', 'textMatch'],
+      cached: false
+    };
+
+    setCache(cacheKey, responsePayload);
+    logDiscoveryEvent({
+      userId: viewerId,
+      eventType: 'discovery_post_impression',
+      metadata: { query, page, limit, count: posts.length },
+      req
+    });
+
+    return res.json(responsePayload);
+  } catch (error) {
+    console.error('Post discovery error:', error);
+    return res.status(500).json({ error: 'Failed to load post discovery results', details: error.message });
+  }
+});
+
+router.post('/events', authenticateToken, discoveryLimiter, async (req, res) => {
+  try {
+    const eventType = String(req.body?.eventType || '').trim();
+    const allowed = new Set(['profile_click', 'post_click', 'follow_click']);
+    if (!allowed.has(eventType)) {
+      return res.status(400).json({ error: 'Invalid discovery eventType' });
+    }
+
+    const metadata = typeof req.body?.metadata === 'object' && req.body.metadata
+      ? req.body.metadata
+      : {};
+
+    logDiscoveryEvent({
+      userId: String(req.user.userId),
+      eventType,
+      metadata,
+      req
+    });
+
+    return res.status(202).json({ success: true });
+  } catch (error) {
+    return res.status(500).json({ error: 'Failed to record discovery event', details: error.message });
+  }
+});
+
+module.exports = router;

--- a/routes/discovery.test.js
+++ b/routes/discovery.test.js
@@ -1,0 +1,195 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('jsonwebtoken', () => ({
+  verify: jest.fn()
+}));
+
+const User = {
+  findById: jest.fn(),
+  find: jest.fn()
+};
+
+const Friendship = {
+  find: jest.fn()
+};
+
+const BlockList = {
+  find: jest.fn()
+};
+
+const Post = {
+  find: jest.fn()
+};
+
+jest.mock('../models/User', () => User);
+jest.mock('../models/Friendship', () => Friendship);
+jest.mock('../models/BlockList', () => BlockList);
+jest.mock('../models/Post', () => Post);
+
+const jwt = require('jsonwebtoken');
+const discoveryRouter = require('./discovery');
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/discovery', discoveryRouter);
+  return app;
+};
+
+const mockAuthUser = () => {
+  jwt.verify.mockImplementation((token, secret, callback) => callback(null, { userId: 'viewer-1' }));
+  User.findById.mockReturnValue({
+    select: jest.fn().mockResolvedValue({
+      _id: 'viewer-1',
+      onboardingStatus: 'completed',
+      city: 'Austin',
+      state: 'TX',
+      country: 'US'
+    })
+  });
+};
+
+const mockFriendAndBlockLookups = () => {
+  Friendship.find.mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      lean: jest.fn().mockResolvedValue([
+        { requester: 'viewer-1', recipient: 'friend-1' }
+      ])
+    })
+  });
+
+  BlockList.find
+    .mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue([])
+      })
+    })
+    .mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue([])
+      })
+    });
+};
+
+describe('Discovery routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns ranked and paginated user discovery results', async () => {
+    const app = buildApp();
+    mockAuthUser();
+    mockFriendAndBlockLookups();
+
+    User.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            lean: jest.fn().mockResolvedValue([
+              {
+                _id: 'u-1',
+                username: 'alice',
+                realName: 'Alice Doe',
+                city: 'Austin',
+                state: 'TX',
+                country: 'US',
+                friendCount: 20,
+                createdAt: new Date('2026-03-01T00:00:00.000Z')
+              },
+              {
+                _id: 'u-2',
+                username: 'zoe',
+                realName: 'Zoe Smith',
+                city: 'Boston',
+                state: 'MA',
+                country: 'US',
+                friendCount: 2,
+                createdAt: new Date('2025-12-01T00:00:00.000Z')
+              }
+            ])
+          })
+        })
+      })
+    });
+
+    const response = await request(app)
+      .get('/api/discovery/users?q=ali&page=1&limit=1')
+      .set('Authorization', 'Bearer token');
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.users).toHaveLength(1);
+    expect(response.body.total).toBe(2);
+    expect(response.body.users[0]).toMatchObject({
+      _id: 'u-1',
+      username: 'alice'
+    });
+    expect(response.body.users[0].ranking.signals).toHaveProperty('textMatch');
+    expect(response.body.users[0].ranking.signals).toHaveProperty('locationSignal');
+    expect(response.body.users[0].ranking.signals).toHaveProperty('socialSignal');
+  });
+
+  it('caches repeated user discovery query responses briefly', async () => {
+    const app = buildApp();
+    mockAuthUser();
+    mockFriendAndBlockLookups();
+
+    User.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            lean: jest.fn().mockResolvedValue([
+              {
+                _id: 'u-1',
+                username: 'alice',
+                realName: 'Alice Doe',
+                city: 'Austin',
+                state: 'TX',
+                country: 'US',
+                friendCount: 3,
+                createdAt: new Date('2026-03-02T00:00:00.000Z')
+              }
+            ])
+          })
+        })
+      })
+    });
+
+    const first = await request(app)
+      .get('/api/discovery/users?q=ali&page=1&limit=10')
+      .set('Authorization', 'Bearer token');
+
+    expect(first.status).toBe(200);
+    expect(first.body.cached).toBe(false);
+
+    const second = await request(app)
+      .get('/api/discovery/users?q=ali&page=1&limit=10')
+      .set('Authorization', 'Bearer token');
+
+    expect(second.status).toBe(200);
+    expect(second.body.cached).toBe(true);
+    expect(User.find).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts click analytics events and rejects invalid event types', async () => {
+    const app = buildApp();
+    mockAuthUser();
+
+    const accepted = await request(app)
+      .post('/api/discovery/events')
+      .set('Authorization', 'Bearer token')
+      .send({ eventType: 'profile_click', metadata: { targetUserId: 'u-1' } });
+
+    expect(accepted.status).toBe(202);
+    expect(accepted.body.success).toBe(true);
+
+    const rejected = await request(app)
+      .post('/api/discovery/events')
+      .set('Authorization', 'Bearer token')
+      .send({ eventType: 'invalid_type' });
+
+    expect(rejected.status).toBe(400);
+    expect(rejected.body.error).toMatch(/invalid discovery eventtype/i);
+  });
+});

--- a/server.js
+++ b/server.js
@@ -155,6 +155,7 @@ registerRoute('/api/friends', () => require('./routes/friends'));
 registerRoute('/api/circles', () => require('./routes/circles'));
 registerRoute('/api/moderation', () => require('./routes/moderation'));
 registerRoute('/api/notifications', () => require('./routes/notifications'));
+registerRoute('/api/discovery', () => require('./routes/discovery'));
 
 let newsRoutes = null;
 let mapsRoutes = null;


### PR DESCRIPTION
Implements #10 with a dedicated discovery workflow.\n\n## What shipped\n- Ranked + paginated discovery endpoints for users and posts\n- Ranking metadata and deterministic tie-break sorting\n- Basic in-memory caching + rate limiting for repeated discovery queries\n- Discovery analytics events for impressions and click/follow actions\n- New frontend Discover page and nav entry\n- Added discovery model indexes + endpoint documentation\n- Added route tests for ranking/pagination, cache behavior, and analytics validation\n\n## Testing\n- Added outes/discovery.test.js\n- Runtime note: Node/npm are unavailable in this shell, so tests could not be executed in-terminal here.\n\nCloses #10